### PR TITLE
feat: implemented sampling for MTP

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -582,3 +582,7 @@ std::vector<common_sampler_type> common_sampler_types_from_chars(const std::stri
 
     return samplers;
 }
+
+void common_sampler_apply_chain(struct common_sampler * gsmpl, struct llama_token_data_array * cur_p) {
+    llama_sampler_apply(gsmpl->chain, cur_p);
+}

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -105,3 +105,5 @@ std::vector<enum common_sampler_type> common_sampler_types_from_chars(const std:
 
 llama_sampler * llama_sampler_init_llg(const llama_vocab * vocab,
                 const char * grammar_kind, const char * grammar_data);
+
+void common_sampler_apply_chain(struct common_sampler * gsmpl, struct llama_token_data_array * cur_p);

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -370,56 +370,20 @@ llama_token mtp_speculative_gen_draft(
     int32_t n_past,
     int32_t last_tok_idx) {
 
-    llama_token token_data[] = { id_last };
-    llama_pos pos_data[] = { n_past };
-    int32_t n_seq_id_data[] = { 1 };
-    llama_seq_id seq_id_data_internal[] = { 0 };
-    llama_seq_id* seq_id_data[] = {seq_id_data_internal};
-    int8_t logits_data[] = { (int8_t) (smpl != nullptr) };
-
-    llama_batch batch = {
-        /*.n_tokens = */    1,
-        /*.token = */       token_data,
-        /*.embd = */        nullptr,
-        /*.pos = */         pos_data,
-        /*.n_seq_id = */    n_seq_id_data,
-        /*.seq_id = */      seq_id_data,
-        /*.logits = */      logits_data
-    };
-
-    return llama_build_and_execute_mtp_graph(ctx, batch, id_last, n_past, last_tok_idx);
-    //LOG_INF("updating kv cache for n_past: %d\n", n_past);
-
-    /*
     if (!smpl) {
         return -1;
     }
-    else {
-        common_sampler_sample(smpl, ctx, last_tok_idx, true);
-        const auto* cur_p = common_sampler_get_candidates(smpl);
 
-        //for (int k = 0; k < std::min(3, (int)cur_p->size); ++k) {
-        //    LOG_INF(" - draft candidate %3d, pos %3d: %6d (%8.3f) '%s'\n",
-        //        k, 0, cur_p->data[k].id, cur_p->data[k].p, common_token_to_piece(ctx, cur_p->data[k].id).c_str());
-        //}
+    llama_batch batch = llama_batch_init(1, 0, 1);
+    common_batch_add(batch, id_last, n_past, {0}, true);
 
-        const llama_token id = cur_p->data[0].id;
-        return id;
-    }
-    */
-    // LOG_INF("cur_p->size: %d\n", cur_p->size);
+    llama_build_and_execute_mtp_graph(ctx, batch, id_last, n_past, last_tok_idx);
 
+    llama_token id = common_sampler_sample(smpl, ctx, last_tok_idx, true);
 
-    // add drafted token for each sequence
+    llama_batch_free(batch);
 
-    // skip accepting draft token -- since we're only drafting one token this can't affect future outputs
-    // smpl will accept the token if it doesn't get rejected by main model later
-    // common_sampler_accept(smpl, id, true);
-
-    //llama_tokens result;
-    //result.reserve(1);
-    //result.push_back(id);
-    //return result;
+    return id;
 }
 
 

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -381,6 +381,14 @@ llama_token mtp_speculative_gen_draft(
 
     llama_token id = common_sampler_sample(smpl, ctx, last_tok_idx, true);
 
+    const auto * cur_p = common_sampler_get_candidates(smpl);
+    for (int k = 0; k < std::min(3, (int)cur_p->size); ++k) {
+        LOG_DBG(" - draft candidate %3d, pos %3d: %6d (%8.3f) '%s'\n",
+            k, 0, cur_p->data[k].id, cur_p->data[k].p, common_token_to_piece(ctx, cur_p->data[k].id).c_str());
+    }
+
+    common_sampler_accept(smpl, id, true);
+
     llama_batch_free(batch);
 
     return id;

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -44,9 +44,9 @@ llama_token mtp_speculative_gen_draft(
 
 // sample up to n_draft tokens and add them to the batch using the draft model
 llama_tokens common_speculative_gen_draft(
-               struct common_speculative * spec,
-        struct common_speculative_params   params,
-                      const llama_tokens & prompt,
-                             llama_token   id_last);
+    struct common_speculative * spec,
+    struct common_speculative_params   params,
+    const llama_tokens & prompt,
+    llama_token   id_last);
 
 void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens, size_t batch_start = 0, size_t n_tokens = -1);

--- a/include/llama.h
+++ b/include/llama.h
@@ -1454,8 +1454,8 @@ extern "C" {
             ggml_opt_epoch_callback   callback_train,
             ggml_opt_epoch_callback   callback_eval);
 
-    LLAMA_API llama_token llama_build_and_execute_mtp_graph(struct llama_context * ctx,
-        const llama_batch batch_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx);
+        LLAMA_API void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
+                const llama_batch batch_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hi @F1LM1, I've been following your PR and decided to tackle one of the to-dos you mentioned: implementing proper sampling for the MTP draft model.

I've successfully implemented a solution that retrieves the full logits from the MTP and passes them to the sampler for the draft token generation. The code seems stable and is ready for your review.

Here are the key results from my testing:

* Greedy Decoding (Temp 0.8): My implementation performed identically to the original PR, with an acceptance rate of 0.756.
* Creative Sampling (Temp 2.0): The performance in my debug tests was initially worse for creativity (acceptance rate of 0.566 vs. your original 0.670). I believe this is because allowing the MTP more freedom to choose a token via sampling can increase the divergence from the main model, leading to lower acceptance.

Interestingly, when compiled in release mode, I achieved an average acceptance rate of 0.51 for creative tasks, which as you mentioned in your PR it was around of 0.4.

I tried to preserve your code and I'm open to suggestions you have for improvement.