### PR TITLE
feat: Enable multi-token drafting for GLM-4.5 MTP

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -582,3 +582,7 @@ std::vector<common_sampler_type> common_sampler_types_from_chars(const std::stri
 
     return samplers;
 }
+
+void common_sampler_apply_chain(struct common_sampler * gsmpl, struct llama_token_data_array * cur_p) {
+    llama_sampler_apply(gsmpl->chain, cur_p);
+}

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -105,3 +105,5 @@ std::vector<enum common_sampler_type> common_sampler_types_from_chars(const std:
 
 llama_sampler * llama_sampler_init_llg(const llama_vocab * vocab,
                 const char * grammar_kind, const char * grammar_data);
+
+void common_sampler_apply_chain(struct common_sampler * gsmpl, struct llama_token_data_array * cur_p);

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -370,56 +370,20 @@ llama_token mtp_speculative_gen_draft(
     int32_t n_past,
     int32_t last_tok_idx) {
 
-    llama_token token_data[] = { id_last };
-    llama_pos pos_data[] = { n_past };
-    int32_t n_seq_id_data[] = { 1 };
-    llama_seq_id seq_id_data_internal[] = { 0 };
-    llama_seq_id* seq_id_data[] = {seq_id_data_internal};
-    int8_t logits_data[] = { (int8_t) (smpl != nullptr) };
-
-    llama_batch batch = {
-        /*.n_tokens = */    1,
-        /*.token = */       token_data,
-        /*.embd = */        nullptr,
-        /*.pos = */         pos_data,
-        /*.n_seq_id = */    n_seq_id_data,
-        /*.seq_id = */      seq_id_data,
-        /*.logits = */      logits_data
-    };
-
-    return llama_build_and_execute_mtp_graph(ctx, batch, id_last, n_past, last_tok_idx);
-    //LOG_INF("updating kv cache for n_past: %d\n", n_past);
-
-    /*
     if (!smpl) {
         return -1;
     }
-    else {
-        common_sampler_sample(smpl, ctx, last_tok_idx, true);
-        const auto* cur_p = common_sampler_get_candidates(smpl);
 
-        //for (int k = 0; k < std::min(3, (int)cur_p->size); ++k) {
-        //    LOG_INF(" - draft candidate %3d, pos %3d: %6d (%8.3f) '%s'\n",
-        //        k, 0, cur_p->data[k].id, cur_p->data[k].p, common_token_to_piece(ctx, cur_p->data[k].id).c_str());
-        //}
+    llama_batch batch = llama_batch_init(1, 0, 1);
+    common_batch_add(batch, id_last, n_past, {0}, true);
 
-        const llama_token id = cur_p->data[0].id;
-        return id;
-    }
-    */
-    // LOG_INF("cur_p->size: %d\n", cur_p->size);
+    llama_build_and_execute_mtp_graph(ctx, batch, id_last, n_past, last_tok_idx);
 
+    llama_token id = common_sampler_sample(smpl, ctx, last_tok_idx, true);
 
-    // add drafted token for each sequence
+    llama_batch_free(batch);
 
-    // skip accepting draft token -- since we're only drafting one token this can't affect future outputs
-    // smpl will accept the token if it doesn't get rejected by main model later
-    // common_sampler_accept(smpl, id, true);
-
-    //llama_tokens result;
-    //result.reserve(1);
-    //result.push_back(id);
-    //return result;
+    return id;
 }
 
 

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -381,6 +381,14 @@ llama_token mtp_speculative_gen_draft(
 
     llama_token id = common_sampler_sample(smpl, ctx, last_tok_idx, true);
 
+    const auto * cur_p = common_sampler_get_candidates(smpl);
+    for (int k = 0; k < std::min(3, (int)cur_p->size); ++k) {
+        LOG_DBG(" - draft candidate %3d, pos %3d: %6d (%8.3f) '%s'\n",
+            k, 0, cur_p->data[k].id, cur_p->data[k].p, common_token_to_piece(ctx, cur_p->data[k].id).c_str());
+    }
+
+    common_sampler_accept(smpl, id, true);
+
     llama_batch_free(batch);
 
     return id;

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -363,57 +363,91 @@ llama_tokens common_speculative_gen_draft(
 }
 
 
-llama_token mtp_speculative_gen_draft(
+llama_tokens mtp_speculative_gen_draft(
     struct common_sampler* smpl,
     struct llama_context* ctx,
     llama_token id_last,
     int32_t n_past,
-    int32_t last_tok_idx) {
+    int32_t last_tok_idx,
+    int32_t n_mtp_draft) {
 
-    if (!smpl) {
-        return -1;
+    llama_tokens draft_tokens;
+    draft_tokens.reserve(n_mtp_draft);
+
+    llama_token current_token = id_last;
+    int32_t current_n_past = n_past;
+
+    float* prev_embedding_data = llama_get_embeddings_ith(ctx, last_tok_idx);
+    LOG_DBG("\n--- MTP total draft %d ---\n", n_mtp_draft);
+    
+    // The same layer will draft multiple tokens before being validated
+    for (int i = 0; i < n_mtp_draft; ++i) {
+        if (prev_embedding_data == nullptr) {
+            LOG_DBG("ERROR: prev_embedding_data is null in iteration %d!\n", i);
+            break;
+        }
+        llama_batch batch = llama_batch_init(1, 0, 1);
+        common_batch_add(batch, current_token, current_n_past, {0}, true);
+
+        float* next_embedding_data = llama_build_and_execute_mtp_graph(
+            ctx, batch, prev_embedding_data, i
+        );
+
+        if (next_embedding_data == nullptr) {
+            LOG_DBG("ERROR: next_embedding_data returned null from graph execution\n", i);
+        }
+
+        // Apply logits + greedy: The main model has not yet selected 
+        // the token as correct, so we cannot apply all samples.
+        const llama_model * model = llama_get_model(ctx);
+        const llama_vocab * vocab = llama_model_get_vocab(model);
+        const int n_vocab = llama_n_vocab(vocab);
+
+        llama_token_data_array* cur_p = common_sampler_get_candidates(smpl);
+        cur_p->size = n_vocab;
+        for (int j = 0; j < n_vocab; ++j) {
+            cur_p->data[j].id = j;
+            // Place the MTP logits in the first slot of the context's logit buffer.
+            // This temporary storage is then read by the sampler.
+            cur_p->data[j].logit = llama_get_logits_ith(ctx, 0)[j];
+        }
+        cur_p->sorted = false;
+        common_sampler_apply_chain(smpl, cur_p);
+
+        const llama_token new_id = cur_p->data[0].id;
+
+        draft_tokens.push_back(new_id);
+
+        current_token = new_id;
+        current_n_past++;
+        prev_embedding_data = next_embedding_data;
+
+        llama_batch_free(batch);
+
+        if (!next_embedding_data) {
+            break;
+        }
     }
 
-    llama_batch batch = llama_batch_init(1, 0, 1);
-    common_batch_add(batch, id_last, n_past, {0}, true);
-
-    llama_build_and_execute_mtp_graph(ctx, batch, id_last, n_past, last_tok_idx);
-
-    const llama_model * model = llama_get_model(ctx);
-    const llama_vocab * vocab = llama_model_get_vocab(model);
-    const int n_vocab = llama_n_vocab(vocab);
-
-    llama_token_data_array * cur_p = common_sampler_get_candidates(smpl);
-
-    cur_p->size = n_vocab;
-    for (int i = 0; i < n_vocab; ++i) {
-        cur_p->data[i].id = i;
-        cur_p->data[i].logit = llama_get_logits_ith(ctx, last_tok_idx)[i];
-    }
-    cur_p->sorted = false;
-
-    common_sampler_apply_chain(smpl, cur_p);
-
-    const llama_token id = cur_p->data[0].id;
-
-    llama_batch_free(batch);
-
-    return id;
+    return draft_tokens;
 }
 
 
 void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens, size_t batch_start, size_t n_tokens) {
-    mtp_kv_update_data token;
-
     if (n_tokens < 0) {
         n_tokens = tokens.size();
     }
 
-    for (int i = 0; i < std::min(tokens.size(), n_tokens); ++i) {
-        token = tokens[i];
-        //fprintf(stderr, "updating mtp kv cache with token  (%d, %d, %d)\n", token.id, token.n_past, (int) (token.tok_idx - batch_start));
+    for (size_t i = 0; i < std::min((size_t)tokens.size(), n_tokens); ++i) {
+        mtp_kv_update_data& token = tokens[i];
+        
+        llama_batch batch = llama_batch_init(1, 0, 1);
+        common_batch_add(batch, token.id, token.n_past, {0}, true);
+        
+        // Broken for now
+        // mtp_speculative_gen_draft(nullptr, ctx, token.id, token.n_past, token.tok_idx - batch_start);
 
-        mtp_speculative_gen_draft(nullptr, ctx, token.id, token.n_past, token.tok_idx - batch_start);
+        llama_batch_free(batch);
     }
 
     tokens.clear();

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -44,9 +44,9 @@ llama_token mtp_speculative_gen_draft(
 
 // sample up to n_draft tokens and add them to the batch using the draft model
 llama_tokens common_speculative_gen_draft(
-               struct common_speculative * spec,
-        struct common_speculative_params   params,
-                      const llama_tokens & prompt,
-                             llama_token   id_last);
+    struct common_speculative * spec,
+    struct common_speculative_params   params,
+    const llama_tokens & prompt,
+    llama_token   id_last);
 
 void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens, size_t batch_start = 0, size_t n_tokens = -1);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -35,12 +35,13 @@ void common_speculative_add_replacement_tgt_dft(
 
 
 // sample up to n_draft tokens and add them to the batch using the draft model
-llama_token mtp_speculative_gen_draft(
+llama_tokens mtp_speculative_gen_draft(
     struct common_sampler* smpl,
     struct llama_context* ctx,
     llama_token id_last,
     int32_t n_past,
-    int32_t last_tok_idx);
+    int32_t last_tok_idx,
+    int32_t n_mtp_draft);
 
 // sample up to n_draft tokens and add them to the batch using the draft model
 llama_tokens common_speculative_gen_draft(

--- a/include/llama.h
+++ b/include/llama.h
@@ -1454,8 +1454,8 @@ extern "C" {
             ggml_opt_epoch_callback   callback_train,
             ggml_opt_epoch_callback   callback_eval);
 
-    LLAMA_API llama_token llama_build_and_execute_mtp_graph(struct llama_context * ctx,
-        const llama_batch batch_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx);
+        LLAMA_API void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
+                const llama_batch batch_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx);
 
 #ifdef __cplusplus
 }

--- a/include/llama.h
+++ b/include/llama.h
@@ -1454,8 +1454,12 @@ extern "C" {
             ggml_opt_epoch_callback   callback_train,
             ggml_opt_epoch_callback   callback_eval);
 
-        LLAMA_API void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
-                const llama_batch batch_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx);
+        LLAMA_API float* llama_build_and_execute_mtp_graph(
+                struct llama_context * ctx,
+                const llama_batch batch_inp,
+                float * prev_embedding_data,
+                int32_t mtp_head_idx
+        );
 
 #ifdef __cplusplus
 }

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2995,16 +2995,19 @@ void llama_opt_epoch(
         callback_eval);
 }
 
-void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
-    const llama_batch batch_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx) {
-
+float* llama_build_and_execute_mtp_graph(
+    struct llama_context * ctx,
+    const llama_batch batch_inp,
+    float * prev_embedding_data,
+    int32_t mtp_head_idx
+) {
     const auto * model = llama_get_model(ctx);
 
     auto res_mtp = std::make_unique<llm_graph_result>(ctx->graph_max_nodes());
     std::unique_ptr<llama_memory_context_i> mctx = ctx->mtp_memory_batch(batch_inp);
 
     std::vector<uint32_t> idxs;
-    idxs.push_back(n_past);
+    idxs.push_back(batch_inp.pos[0]);
     llama_kv_cache_unified::slot_info sinfo = {
         /*.s0   =*/ 0,
         /*.s1   =*/ 0,
@@ -3024,50 +3027,64 @@ void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
     auto params_mtp = std::make_unique<llm_graph_params>(ctx->mtp_graph_params(res_mtp.get(), ubatch_mtp, mctx.get()));
     ggml_backend_sched_t sched = params_mtp->sched;
 
-    auto * last_embd = ctx->get_embeddings_ith(last_tok_idx);
-
     //if (mctx && !mctx->set_n_kv()) {
     //    LLAMA_LOG_ERROR("%s: failed to apply memory context\n", __func__);
     //}
     static_cast<llama_kv_cache_unified_context*>(mctx.get())->set_n_kv();
 
-    auto * gf = model->build_mtp_graph(*params_mtp, last_token_id, n_past);
+    auto * gf = model->build_mtp_graph(*params_mtp, mtp_head_idx);
 
     if (!gf) {
         LLAMA_LOG_ERROR("%s: ERROR - The construction of the MTP graph failed (returned null).", __func__);
         if (sched) ggml_backend_sched_free(sched);
-        return;
+        return nullptr;
     }
 
     ggml_backend_sched_reset(sched); // clear the allocation of the previous graph
     ggml_backend_sched_alloc_graph(sched, gf); // explicitly allocate the new graph but do not execute it
 
+    llama_token token_id = batch_inp.token[0];
     ggml_tensor * mtp_token_id_input = ggml_get_tensor(res_mtp->get_ctx(), "mtp_token_id_input");
-    ggml_backend_tensor_set(mtp_token_id_input, &last_token_id, 0, sizeof(last_token_id)); // copy data to the newly allocated graph tensors
+    ggml_backend_tensor_set(mtp_token_id_input, &token_id, 0, sizeof(token_id)); // copy data to the newly allocated graph tensors
 
     ggml_tensor * mtp_prev_embedding_input = ggml_get_tensor(res_mtp->get_ctx(), "mtp_prev_embedding_input");
-    ggml_backend_tensor_set(mtp_prev_embedding_input, last_embd, 0, ggml_nbytes(mtp_prev_embedding_input)); // copy data to the newly allocated graph tensors
+
+    if (mtp_prev_embedding_input) {
+        ggml_backend_tensor_set(mtp_prev_embedding_input, prev_embedding_data, 0,
+             ggml_nbytes(mtp_prev_embedding_input)); // copy data to the newly allocated graph tensors
+    } else {
+        LLAMA_LOG_WARN("%s: Could not find 'mtp_prev_embedding_input' tensor in the MTP graph.\n", __func__);
+    }
 
     ggml_backend_sched_graph_compute(sched, gf); // execute the graph
 
     struct ggml_tensor * logits_mtp = res_mtp->get_logits();
 
     if (logits_mtp) {
-        float * logits_dest = ctx->get_logits_ith(last_tok_idx);
-        ggml_backend_t backend_res = ggml_backend_sched_get_tensor_backend(sched, logits_mtp);
-        if (backend_res) {
-            // ggml_backend_tensor_get is the function for GPU->CPU copies.
-            // We are copying a single 32-bit integer.
-            ggml_backend_tensor_get(logits_mtp, 
-                                    logits_dest, // Pointer to our C++ variable
-                                    0,          // Starting offset in bytes
-                                    ggml_nbytes(logits_mtp)); // Number of bytes to copy
+        float * logits_dest = llama_get_logits_ith(ctx, 0);
+        // ggml_backend_tensor_get is the function for GPU->CPU copies.
+        // We are copying a single 32-bit integer.
+        ggml_backend_tensor_get(logits_mtp, 
+                                logits_dest, // Pointer to our C++ variable
+                                0,          // Starting offset in bytes
+                                ggml_nbytes(logits_mtp)); // Number of bytes to copy
         } else {
-            LLAMA_LOG_ERROR("%s: ERROR - Could not obtain the backend for the logits tensor.", __func__);
-        }
-    } else {
         LLAMA_LOG_WARN("%s: WARNING - The MTP graph did not produce a logit tensor.", __func__);
     }
 
+    struct ggml_tensor * next_embedding_tensor = ggml_get_tensor(res_mtp->get_ctx(), "mtp_next_embedding_output");
+    float * next_embedding_data_ptr = nullptr;
+
+    if (next_embedding_tensor) {
+        if (ctx->mtp_embedding_buffer.size() < ggml_nbytes(next_embedding_tensor)) {
+            ctx->mtp_embedding_buffer.resize(ggml_nbytes(next_embedding_tensor));
+        }
+        ggml_backend_tensor_get(next_embedding_tensor, ctx->mtp_embedding_buffer.data(), 0, ggml_nbytes(next_embedding_tensor));
+        next_embedding_data_ptr = reinterpret_cast<float *>(ctx->mtp_embedding_buffer.data());
+    } else {
+        LLAMA_LOG_ERROR("%s: The MTP graph did not produce an output embedding tensor.\n", __func__);
+    }
+
     ggml_backend_sched_free(sched);
+    return next_embedding_data_ptr;
 }

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -207,6 +207,8 @@ public:
     ggml_backend_sched_t create_temp_scheduler(size_t n_nodes);
 
     std::unique_ptr<llama_memory_context_i> mtp_memory_batch(const llama_batch& batch_inp);
+    
+    std::vector<uint8_t> mtp_embedding_buffer;
 
 private:
     llm_graph_params graph_params(

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -13947,15 +13947,20 @@ struct llm_build_glm4_moe : public llm_graph_context {
 
 struct llm_build_glm4_moe_mtp : public llm_graph_context {
     llm_build_glm4_moe_mtp(const llama_model & model, const llm_graph_params & params,
+        int mtp_head_idx) : llm_graph_context(params) {
         // For v0, let's rebuild the computational graph for every step + this mimics the vLLM impl parameterization
-        llama_token last_token_id, int n_past
-    ) : llm_graph_context(params) {
 
         const int64_t n_embd_head = hparams.n_embd_head_v;
         GGML_ASSERT(n_embd_head == hparams.n_embd_head_k);
 
         // Assuming a single MTP layer at the end
         const int il = hparams.n_layer - 1;
+
+        if (il < 0 || il >= (int)model.layers.size()) {
+            LLAMA_LOG_ERROR("FATAL ERROR: Calculated MTP layer index (%d) is out of bounds! The number of layers is %zu.\n", 
+                il, model.layers.size());
+            GGML_ABORT("fatal error");
+        }
         const auto & mtp_layer = model.layers[il];
 
         // ggml_tensor * inp_pos = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, 1);
@@ -14089,13 +14094,20 @@ struct llm_build_glm4_moe_mtp : public llm_graph_context {
             cur = ggml_add(ctx0, routed_out, shared_out);
             cb(cur, "ffn_out", il);
         }
+        ggml_tensor* final_hidden_state = cur;
         cur = ggml_add(ctx0, cur, ffn_inp);
 
         cur = build_norm(cur, mtp_layer.nextn.shared_head_norm, NULL, LLM_NORM_RMS, il);
         cur = build_lora_mm(mtp_layer.nextn.shared_head_head, cur);
-        
+
         res->t_logits = cur;
+
+        ggml_set_name(final_hidden_state, "mtp_next_embedding_output");
+        ggml_set_output(final_hidden_state);
+
         ggml_build_forward_expand(gf, res->t_logits);
+        ggml_build_forward_expand(gf, final_hidden_state);
+
     }
 };
 
@@ -18690,13 +18702,13 @@ ggml_cgraph * llama_model::build_graph(const llm_graph_params & params) const {
 }
 
 ggml_cgraph * llama_model::build_mtp_graph(const llm_graph_params& params,
-    llama_token last_token_id, int n_past) const {
+    int mtp_head_idx) const {
     std::unique_ptr<llm_graph_context> llm;
 
     switch (arch) {
     case LLM_ARCH_GLM4_MOE:
     {
-        llm = std::make_unique<llm_build_glm4_moe_mtp>(*this, params, last_token_id, n_past);
+        llm = std::make_unique<llm_build_glm4_moe_mtp>(*this, params, mtp_head_idx);
     } break;
     default:
         GGML_ABORT("fatal error");

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -475,8 +475,7 @@ struct llama_model {
 
     // TODO: move this to new llm_arch_model_i interface
     ggml_cgraph * build_graph(const llm_graph_params & params) const;
-    ggml_cgraph * build_mtp_graph(const llm_graph_params & params,
-        llama_token last_token_id, int n_past) const;
+    ggml_cgraph * build_mtp_graph(const llm_graph_params& params, int mtp_head_idx) const;
 
 private:
     struct impl;

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -2138,12 +2138,14 @@ struct server_context {
                 SRV_INF("model has nextn layers = %d\n", llama_model_n_nextn_layer(model));
                 slot.has_mtp = true;
 
-                // assume one speculative token (true of all well-known MTP models so far)
-                slot.batch_spec = llama_batch_init(2, 0, 1);
+                // TODO: Build token argument for MTP
+                const int n_mtp_draft_target = 5; 
+
+                slot.batch_spec = llama_batch_init(1 + n_mtp_draft_target, 0, 1);
                 SLT_DBG(slot, "batch_spec contains %d tokens\n", slot.batch_spec.n_tokens);
 
                 params_base.speculative.n_min = 0;
-                params_base.speculative.n_max = 1;
+                params_base.speculative.n_max = n_mtp_draft_target;
 
                 SRV_INF("%s\n", "MTP needs embeddings on decode, enabling");
                 llama_set_embeddings(ctx, true);
@@ -3637,9 +3639,9 @@ struct server_context {
 
                 llama_tokens draft;
                 if (slot.has_mtp) {
-                    llama_token draft_id = mtp_speculative_gen_draft(slot.smpl, ctx, id, slot.n_past, slot.last_tok_idx);
-                    draft.reserve(1);
-                    draft.push_back(draft_id);
+                    int n_draft = std::min(n_draft_max, slot.params.speculative.n_max);
+
+                    draft = mtp_speculative_gen_draft(slot.smpl, ctx, id, slot.n_past, slot.last_tok_idx, n_draft);
                 }
                 else {
                     struct common_speculative_params params_spec;


### PR DESCRIPTION
For now, this is just a proof of concept I had in mind. I tried to replicate the workflow from SGLang because even with a proper implementation in vLLM, they are not drafting more than one token, as stated in this [comment](https://github.com/vllm-project/vllm/pull/20736#issuecomment-3089852373) on their PR.

The drafting process must be an autoregressive loop to accommodate the CPU-side sampling required between each token generation. In case you are curious, the loop in SGLang looks like this:

```python
# in sglang/srt/speculative/eagle_worker.py
class EAGLEWorker:
    ...
    def draft_forward(self, forward_batch: ForwardBatch):
        ...
        # Forward multiple steps
        scores = None
        for i in range(self.speculative_num_steps):
            # Selects the input tokens for this iteration
            input_ids, hidden_states, scores, tree_info = select_top_k_tokens(...)
            
            # ... (saves the results)

            # Stop generating after the last required step
            if i == self.speculative_num_steps - 1:
                break

            # Prepares the inputs for the next model run
            forward_batch.input_ids = input_ids
            # ... (other batch preparations)

            # Executes the draft model for ONE step
            logits_output, _ = self.draft_model_runner.forward(
                forward_batch, skip_attn_backend_init=True
            )
            
            # Samples the logits to obtain tokens for the NEXT iteration
            probs = torch.softmax(logits_output.next_token_logits, dim=-1)
            topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
            hidden_states = logits_output.hidden_states

        return score_list, token_list, parents_list
```

With that in mind, I implemented a loop for `mtp_speculative_gen_draft` based on how many draft tokens you want at once, which gives us a similar idea.

The major problem is a significant limitation regarding KV cache management; the KV cache is not persisted between draft steps, leading to a degradation in draft quality as more tokens are generated.

Here are some preliminary results showing the drop in acceptance rate (It's hardcoded for now to run 5 drafts at once in the line const int n_mtp_draft_target = 5):

- 1 draft: draft acceptance rate = 0.64045 ( 57 accepted / 89 generated)
- 2 drafts: draft acceptance rate = 0.41765 ( 71 accepted / 170 generated)
- 3 drafts: draft acceptance rate = 0.31481 ( 68 accepted / 216 generated)
- 4 drafts: draft acceptance rate = 0.25309 ( 82 accepted / 324 generated)
- 5 drafts: draft acceptance rate = 0.16667 ( 55 accepted / 330 generated)

If my concept is correct, then we "just" need to fix the KV cache, and here is the nightmare that you probably walked before. A proper solution would likely involve creating a persistent KV cache context for the duration of the draft loop.

I can see two options to follow:

1.  Continue down this path to fix the KV Cache (and I would recommend doing that only after your `server: implement GLM-style MTP` PR is merged).
2.  Deliver this simplified version with only 1 draft token. This would align with vLLM's current safe implementation for GLM-4.5 and still provide a performance benefit.