### PR TITLE
mtp-batch: batch prompt processing

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -436,10 +436,13 @@ void mtp_accept_tokens(
         return;
     }
 
+    // Prepare a resized copy of the validation sinfo to match the number of accepted tokens.
+    //    This sets up the context for a "forced sinfo" decode.
     if (!llama_mtp_prepare_sinfo_for_update(ctx, ids.size())) {
         return;
     }
 
+    // Build a new batch containing only the accepted tokens.
     llama_batch accepted_batch = llama_batch_init(ids.size(), 0, 1);
     for (size_t i = 0; i < ids.size(); ++i) {
         common_batch_add(accepted_batch, ids[i], n_past_base + i, { seq_id }, true);
@@ -447,6 +450,7 @@ void mtp_accept_tokens(
 
     mtp_update_kv_cache(ctx, accepted_batch, false);
 
+    // Clean up the forced state to not affect subsequent, normal decode calls.
     llama_mtp_cancel_sinfo_update(ctx);
 
     llama_batch_free(accepted_batch);

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -374,6 +374,8 @@ llama_token mtp_speculative_gen_draft(
         return -1;
     }
     llama_batch mtp_batch = llama_batch_init(1, 0, 1);
+    const llama_pos draft_pos = n_past;
+    const llama_seq_id draft_seq_id = 0;
     common_batch_add(mtp_batch, id_last, n_past, {0}, true);
 
     mtp_batch.update_mtp_kv = false;
@@ -386,6 +388,8 @@ llama_token mtp_speculative_gen_draft(
 
     llama_decode(ctx, mtp_batch);
     llama_batch_free(mtp_batch);
+
+    llama_kv_cache_seq_rm(ctx, draft_seq_id, draft_pos, draft_pos + 1);
 
     const llama_model * model = llama_get_model(ctx);
     const llama_vocab * vocab = llama_model_get_vocab(model);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -49,7 +49,6 @@ llama_tokens common_speculative_gen_draft(
     const llama_tokens & prompt,
     llama_token   id_last);
 
-void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens, 
-                        bool is_prompt_warmup);
+void mtp_update_kv_cache(struct llama_context * ctx, const llama_batch& batch, bool is_prompt_warmup);
 
 double calculate_vector_sum_double(const float* vec, size_t size);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -49,4 +49,4 @@ llama_tokens common_speculative_gen_draft(
     const llama_tokens & prompt,
     llama_token   id_last);
 
-void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens, size_t batch_start = 0, size_t n_tokens = -1);
+void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -49,4 +49,7 @@ llama_tokens common_speculative_gen_draft(
     const llama_tokens & prompt,
     llama_token   id_last);
 
-void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens, const char* tag);
+void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens, 
+                        bool is_prompt_warmup);
+
+double calculate_vector_sum_double(const float* vec, size_t size);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -49,4 +49,4 @@ llama_tokens common_speculative_gen_draft(
     const llama_tokens & prompt,
     llama_token   id_last);
 
-void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens);
+void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens, const char* tag);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -51,4 +51,11 @@ llama_tokens common_speculative_gen_draft(
 
 void mtp_update_kv_cache(struct llama_context * ctx, const llama_batch& batch, bool is_prompt_warmup);
 
+void mtp_accept_tokens(
+    struct llama_context * ctx,
+    const std::vector<llama_token> & ids,
+    int32_t n_past_base,
+    llama_seq_id seq_id
+);
+
 double calculate_vector_sum_double(const float* vec, size_t size);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -57,5 +57,3 @@ void mtp_accept_tokens(
     int32_t n_past_base,
     llama_seq_id seq_id
 );
-
-double calculate_vector_sum_double(const float* vec, size_t size);

--- a/include/llama.h
+++ b/include/llama.h
@@ -1466,14 +1466,36 @@ extern "C" {
             ggml_opt_epoch_callback   callback_train,
             ggml_opt_epoch_callback   callback_eval);
 
+    //
+    // MTP
+    //
+
     LLAMA_API void llama_set_draft_input_hidden_state(struct llama_context * ctx, const float * hidden_state);
 
+    /**
+     * @brief Prepares the context for an MTP KV cache update by creating a resized copy of the last sinfo.
+     *        This is used after speculative validation when only a subset of draft tokens are accepted.
+     * @param n_accepted The number of tokens that were accepted and for which the sinfo should be resized.
+     * @return true on success.
+     */
     LLAMA_API bool llama_mtp_prepare_sinfo_for_update(struct llama_context * ctx, size_t n_accepted);
     
+    /**
+     * @brief Prepares the context for an MTP KV cache update by reusing the sinfo from the last main model decode.
+     *        This is used for the prompt warmup to ensure the MTP and main model KV caches are perfectly aligned.
+     * @return true on success.
+     */
     LLAMA_API bool llama_mtp_prepare_sinfo_for_warmup(struct llama_context * ctx);
     
+    /**
+     * @brief Clears the forced sinfo state from the context. Must be called after a decode that used a prepared sinfo.
+     */
     LLAMA_API void llama_mtp_cancel_sinfo_update(struct llama_context * ctx);
 
+    /**
+     * @brief Removes KV cache metadata for a specified sequence and token range.
+     *        This makes the physical cells logically available again without deleting the tensor data.
+     */
     LLAMA_API void llama_kv_cache_seq_rm(struct llama_context * ctx, llama_seq_id seq_id, llama_pos p0, llama_pos p1);
 
 #ifdef __cplusplus

--- a/include/llama.h
+++ b/include/llama.h
@@ -1460,8 +1460,12 @@ extern "C" {
     LLAMA_API void llama_set_draft_input_hidden_state(struct llama_context * ctx, const float * hidden_state);
 
     LLAMA_API bool llama_mtp_prepare_sinfo_for_update(struct llama_context * ctx, size_t n_accepted);
-
+    
+    LLAMA_API bool llama_mtp_prepare_sinfo_for_warmup(struct llama_context * ctx);
+    
     LLAMA_API void llama_mtp_cancel_sinfo_update(struct llama_context * ctx);
+
+    LLAMA_API void llama_kv_cache_seq_rm(struct llama_context * ctx, llama_seq_id seq_id, llama_pos p0, llama_pos p1);
 
 #ifdef __cplusplus
 }

--- a/include/llama.h
+++ b/include/llama.h
@@ -230,6 +230,7 @@ extern "C" {
         int32_t      *  n_seq_id;
         llama_seq_id ** seq_id;
         int8_t       *  logits;   // TODO: rename this to "output"
+        bool update_mtp_kv; 
     } llama_batch;
 
     enum llama_model_kv_override_type {
@@ -1454,8 +1455,8 @@ extern "C" {
             ggml_opt_epoch_callback   callback_train,
             ggml_opt_epoch_callback   callback_eval);
 
-        LLAMA_API void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
-                const llama_batch batch_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx);
+        // LLAMA_API void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
+        //         const llama_batch batch_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx);
 
 #ifdef __cplusplus
 }

--- a/include/llama.h
+++ b/include/llama.h
@@ -221,6 +221,17 @@ extern "C" {
     //               - if not:        only the last token is output
     //            )
     //
+    typedef enum {
+        MTP_OP_NONE,
+        MTP_OP_WARMUP,
+        MTP_OP_UPDATE_ACCEPTED,
+        MTP_OP_DRAFT_GEN,
+    } llama_mtp_op_type;
+
+    typedef struct llama_mtp_params {
+        llama_mtp_op_type op_type;
+    } llama_mtp_params;
+
     typedef struct llama_batch {
         int32_t n_tokens;
 
@@ -230,9 +241,7 @@ extern "C" {
         int32_t      *  n_seq_id;
         llama_seq_id ** seq_id;
         int8_t       *  logits;   // TODO: rename this to "output"
-        bool            update_mtp_kv; 
-        bool            use_mtp_head;
-        bool            is_mtp_prompt_warmup;
+        llama_mtp_params mtp_params;
     } llama_batch;
 
     enum llama_model_kv_override_type {

--- a/include/llama.h
+++ b/include/llama.h
@@ -1457,7 +1457,11 @@ extern "C" {
             ggml_opt_epoch_callback   callback_train,
             ggml_opt_epoch_callback   callback_eval);
 
-        LLAMA_API void llama_set_draft_input_hidden_state(struct llama_context * ctx, const float * hidden_state);
+    LLAMA_API void llama_set_draft_input_hidden_state(struct llama_context * ctx, const float * hidden_state);
+
+    LLAMA_API bool llama_mtp_prepare_sinfo_for_update(struct llama_context * ctx, size_t n_accepted);
+
+    LLAMA_API void llama_mtp_cancel_sinfo_update(struct llama_context * ctx);
 
 #ifdef __cplusplus
 }

--- a/include/llama.h
+++ b/include/llama.h
@@ -232,6 +232,7 @@ extern "C" {
         int8_t       *  logits;   // TODO: rename this to "output"
         bool            update_mtp_kv; 
         bool            use_mtp_head;
+        bool            is_mtp_prompt_warmup;
     } llama_batch;
 
     enum llama_model_kv_override_type {

--- a/include/llama.h
+++ b/include/llama.h
@@ -230,7 +230,8 @@ extern "C" {
         int32_t      *  n_seq_id;
         llama_seq_id ** seq_id;
         int8_t       *  logits;   // TODO: rename this to "output"
-        bool update_mtp_kv; 
+        bool            update_mtp_kv; 
+        bool            use_mtp_head;
     } llama_batch;
 
     enum llama_model_kv_override_type {
@@ -1455,8 +1456,7 @@ extern "C" {
             ggml_opt_epoch_callback   callback_train,
             ggml_opt_epoch_callback   callback_eval);
 
-        // LLAMA_API void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
-        //         const llama_batch batch_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx);
+        LLAMA_API void llama_set_draft_input_hidden_state(struct llama_context * ctx, const float * hidden_state);
 
 #ifdef __cplusplus
 }

--- a/src/llama-batch.cpp
+++ b/src/llama-batch.cpp
@@ -841,6 +841,7 @@ struct llama_batch llama_batch_init(int32_t n_tokens_alloc, int32_t embd, int32_
         /*n_seq_id      =*/ nullptr,
         /*seq_id        =*/ nullptr,
         /*logits        =*/ nullptr,
+        /*.use_mtp_head =*/ false,
         /*update_mtp_kv =*/ false,
     };
 

--- a/src/llama-batch.cpp
+++ b/src/llama-batch.cpp
@@ -841,9 +841,7 @@ struct llama_batch llama_batch_init(int32_t n_tokens_alloc, int32_t embd, int32_
         /*n_seq_id      =*/ nullptr,
         /*seq_id        =*/ nullptr,
         /*logits        =*/ nullptr,
-        /*.use_mtp_head =*/ false,
-        /*update_mtp_kv =*/ false,
-        /*.is_mtp_prompt_warmup =*/ false,
+        /*.mtp_params   =*/ { MTP_OP_NONE },
     };
 
     if (embd) {

--- a/src/llama-batch.cpp
+++ b/src/llama-batch.cpp
@@ -843,6 +843,7 @@ struct llama_batch llama_batch_init(int32_t n_tokens_alloc, int32_t embd, int32_
         /*logits        =*/ nullptr,
         /*.use_mtp_head =*/ false,
         /*update_mtp_kv =*/ false,
+        /*.is_mtp_prompt_warmup =*/ false,
     };
 
     if (embd) {

--- a/src/llama-batch.cpp
+++ b/src/llama-batch.cpp
@@ -834,13 +834,14 @@ struct llama_batch llama_batch_get_one(
 
 struct llama_batch llama_batch_init(int32_t n_tokens_alloc, int32_t embd, int32_t n_seq_max) {
     llama_batch batch = {
-        /*n_tokens =*/ 0,
-        /*tokens   =*/ nullptr,
-        /*embd     =*/ nullptr,
-        /*pos      =*/ nullptr,
-        /*n_seq_id =*/ nullptr,
-        /*seq_id   =*/ nullptr,
-        /*logits   =*/ nullptr,
+        /*n_tokens      =*/ 0,
+        /*tokens        =*/ nullptr,
+        /*embd          =*/ nullptr,
+        /*pos           =*/ nullptr,
+        /*n_seq_id      =*/ nullptr,
+        /*seq_id        =*/ nullptr,
+        /*logits        =*/ nullptr,
+        /*update_mtp_kv =*/ false,
     };
 
     if (embd) {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1146,7 +1146,14 @@ int llama_context::decode(const llama_batch & batch_inp) {
             // needs to happen before the graph is built
             n_outputs = n_outputs_new;
         }
-
+        if (do_mtp_kv_update) {
+            LLAMA_LOG_WARN("[DEBUG-MTP-UPDATE] MTP KV Update ubatch: n_tokens=%d\n", ubatch.n_tokens);
+            std::string positions_str;
+            for (int i = 0; i < ubatch.n_tokens; ++i) {
+                positions_str += std::to_string(ubatch.pos[i]) + " ";
+            }
+            LLAMA_LOG_WARN("[DEBUG-MTP-UPDATE] Positions: %s\n", positions_str.c_str());
+        }
         ggml_status status;
         const auto * res = process_ubatch(ubatch, LLM_GRAPH_TYPE_DECODER, mctx.get(), status, do_mtp_kv_update, use_mtp_head);
 

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -99,7 +99,8 @@ struct llama_context {
                 const llama_ubatch & ubatch,
                     llm_graph_type   gtype,
             llama_memory_context_i * mctx,
-                       ggml_status & ret);
+                       ggml_status & ret,
+                const bool do_mtp_kv_update);
 
     int encode(const llama_batch & batch_inp);
     int decode(const llama_batch & batch_inp);
@@ -200,8 +201,6 @@ public:
     // reserve a graph with a dummy ubatch of the specified size
     ggml_cgraph * graph_reserve(uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_context_i * mctx);
 
-    llm_graph_params mtp_graph_params(llm_graph_result * res, const llama_ubatch & ubatch, const llama_memory_context_i * mctx);
-
     void set_logits_ith(struct ggml_tensor * logit_override, ggml_backend_sched_t sched_override, int32_t i);
 
     ggml_backend_sched_t create_temp_scheduler(size_t n_nodes);
@@ -213,7 +212,8 @@ private:
                         llm_graph_result * res,
                       const llama_ubatch & ubatch,
             const llama_memory_context_i * mctx,
-                          llm_graph_type   gtype) const;
+                          llm_graph_type   gtype,
+                           bool update_mtp_kv) const;
 
     llm_graph_cb graph_get_cb(ggml_backend_sched * sched_override = nullptr) const;
 

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -30,6 +30,10 @@ struct llama_context {
 
     ~llama_context();
     
+    // The llama_context manages significant resources (GPU memory, file handles, PImpl data)
+    // and is fundamentally a non-copyable, non-movable object. Deleting these special
+    // member functions enforces this rule and is also technically required to allow the
+    // PImpl pattern (via unique_ptr or void*) with an incomplete type in the header.
     llama_context(const llama_context &) = delete;
     llama_context & operator=(const llama_context &) = delete;
     llama_context(llama_context &&) = delete;

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -103,7 +103,8 @@ struct llama_context {
             llama_memory_context_i * mctx,
                        ggml_status & ret,
                 const bool do_mtp_kv_update,
-                const bool use_mtp_head);
+                const bool use_mtp_head,
+                bool is_mtp_prompt_warmup);
 
     int encode(const llama_batch & batch_inp);
     int decode(const llama_batch & batch_inp);

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -111,9 +111,7 @@ struct llama_context {
                     llm_graph_type   gtype,
             llama_memory_context_i * mctx,
                        ggml_status & ret,
-                const bool do_mtp_kv_update,
-                const bool use_mtp_head,
-                bool is_mtp_prompt_warmup);
+                const llama_mtp_params & mtp_params);
 
     int encode(const llama_batch & batch_inp);
     int decode(const llama_batch & batch_inp);
@@ -229,8 +227,7 @@ private:
                       const llama_ubatch & ubatch,
             const llama_memory_context_i * mctx,
                           llm_graph_type   gtype,
-                           bool update_mtp_kv,
-                           bool use_mtp_head) const;
+                           const llama_mtp_params & mtp_params) const;
 
     llm_graph_cb graph_get_cb(ggml_backend_sched * sched_override = nullptr) const;
 

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -231,6 +231,14 @@ private:
 
     llm_graph_cb graph_get_cb(ggml_backend_sched * sched_override = nullptr) const;
 
+    // Methods for MTP decode     
+    std::unique_ptr<llama_memory_context_i> initialize_decode_context(const llama_batch & batch_inp, const bool output_all);
+
+    bool prepare_mtp_graph_inputs(
+        llm_graph_result * res,
+        const llama_ubatch & ubatch,
+        const llama_mtp_params & mtp_params);
+
     // TODO: read/write lora adapters and cvec
     size_t state_write_data(llama_io_write_i & io);
     size_t state_read_data (llama_io_read_i  & io);

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -20,6 +20,8 @@ class llama_io_write_i;
 struct llama_memory_i;
 struct llama_memory_context_i;
 
+struct llama_context_kv_cache_data;
+
 struct llama_context {
     // init scheduler and compute buffers, reserve worst-case graphs
     llama_context(
@@ -27,6 +29,11 @@ struct llama_context {
                   llama_context_params params);
 
     ~llama_context();
+    
+    llama_context(const llama_context &) = delete;
+    llama_context & operator=(const llama_context &) = delete;
+    llama_context(llama_context &&) = delete;
+    llama_context & operator=(llama_context &&) = delete;
 
     void synchronize();
 
@@ -210,6 +217,9 @@ public:
     ggml_backend_sched_t create_temp_scheduler(size_t n_nodes);
 
     std::unique_ptr<llama_memory_context_i> mtp_memory_batch(const llama_batch& batch_inp);
+
+    // For MTP KV cache cell reuse
+    void * kv_cache_data;
 
 private:
     llm_graph_params graph_params(

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -61,6 +61,8 @@ struct llama_context {
     float * get_embeddings_seq(llama_seq_id seq_id);
     ggml_tensor * get_embeddings_tensor();
 
+    const float * draft_input_hidden_state = nullptr;
+
     void attach_threadpool(
             ggml_threadpool_t threadpool,
             ggml_threadpool_t threadpool_batch);
@@ -100,7 +102,8 @@ struct llama_context {
                     llm_graph_type   gtype,
             llama_memory_context_i * mctx,
                        ggml_status & ret,
-                const bool do_mtp_kv_update);
+                const bool do_mtp_kv_update,
+                const bool use_mtp_head);
 
     int encode(const llama_batch & batch_inp);
     int decode(const llama_batch & batch_inp);
@@ -213,7 +216,8 @@ private:
                       const llama_ubatch & ubatch,
             const llama_memory_context_i * mctx,
                           llm_graph_type   gtype,
-                           bool update_mtp_kv) const;
+                           bool update_mtp_kv,
+                           bool use_mtp_head) const;
 
     llm_graph_cb graph_get_cb(ggml_backend_sched * sched_override = nullptr) const;
 

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -100,6 +100,8 @@ struct llama_context {
                 int32_t   il_start,
                 int32_t   il_end);
 
+    void kv_cache_seq_rm(llama_seq_id seq_id, llama_pos p0, llama_pos p1);
+
     // process a single ubatch with a specific graph type
     // if memory_context is provided, it will be applied first to the context's memory
     // ret contains the status of the graph computation

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1074,6 +1074,26 @@ ggml_tensor * llm_graph_context::build_inp_embd(ggml_tensor * tok_embd) const {
     return cur;
 }
 
+
+ggml_tensor * llm_graph_context::build_inp_embd_mtp(ggml_tensor * mtp_tok_embd) const {
+    auto inp = std::make_unique<llm_graph_input_embd>();
+    ggml_tensor * cur = nullptr;
+
+    if (ubatch.token) {
+        inp->tokens = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, ubatch.n_tokens);
+        ggml_set_name(inp->tokens, "mtp_inp_tokens");
+        ggml_set_input(inp->tokens);
+
+        cur = ggml_get_rows(ctx0, mtp_tok_embd, inp->tokens);
+    } else {
+        GGML_ABORT("fatal error: MTP update expects token IDs, not embeddings");
+    }
+
+    cb(cur, "mtp_inp_embd", -1);
+    res->add_input(std::move(inp));
+    return cur;
+}
+
 ggml_tensor * llm_graph_context::build_inp_pos() const {
     auto inp = std::make_unique<llm_graph_input_pos>(hparams.n_pos_per_embd());
 

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -664,6 +664,7 @@ struct llm_graph_context {
     //
 
     ggml_tensor * build_inp_embd(ggml_tensor * tok_embd) const;
+    ggml_tensor * build_inp_embd_mtp(ggml_tensor * mtp_tok_embd) const;
     ggml_tensor * build_inp_pos() const;
     ggml_tensor * build_inp_attn_scale() const;
     ggml_tensor * build_inp_out_ids() const;

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -417,8 +417,7 @@ struct llm_graph_params {
     const llama_adapter_loras    * loras;
     const llama_memory_context_i * mctx;
     const llama_cross            * cross;
-    bool update_mtp_kv;
-    bool use_mtp_head;
+    llama_mtp_params             mtp_params;
 
     uint32_t n_outputs;
 
@@ -467,8 +466,7 @@ struct llm_graph_params {
             cvec      == other.cvec  &&
             loras     == other.loras &&
             cross     == other.cross &&
-            update_mtp_kv == other.update_mtp_kv &&
-            use_mtp_head  == other.use_mtp_head  &&
+            mtp_params.op_type == other.mtp_params.op_type &&
             n_outputs == other.n_outputs;
     }
 };

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -29,6 +29,7 @@ enum llm_graph_type {
     LLM_GRAPH_TYPE_DEFAULT,
     LLM_GRAPH_TYPE_ENCODER,
     LLM_GRAPH_TYPE_DECODER,
+    LLM_GRAPH_TYPE_DRAFT,
 };
 
 enum llm_ffn_op_type {
@@ -93,6 +94,20 @@ public:
 };
 
 using llm_graph_input_ptr = std::unique_ptr<llm_graph_input_i>;
+
+class llm_graph_input_mtp_states : public llm_graph_input_i {
+public:
+    llm_graph_input_mtp_states()          = default;
+    virtual ~llm_graph_input_mtp_states() = default;
+
+    void set_input(const llama_ubatch * /*ubatch*/) override {}
+
+    bool can_reuse(const llm_graph_params & /*params*/) override {
+        return true;
+    }
+
+    ggml_tensor * states = nullptr;
+};
 
 class llm_graph_input_embd : public llm_graph_input_i {
 public:
@@ -403,6 +418,7 @@ struct llm_graph_params {
     const llama_memory_context_i * mctx;
     const llama_cross            * cross;
     bool update_mtp_kv;
+    bool use_mtp_head;
 
     uint32_t n_outputs;
 
@@ -451,6 +467,8 @@ struct llm_graph_params {
             cvec      == other.cvec  &&
             loras     == other.loras &&
             cross     == other.cross &&
+            update_mtp_kv == other.update_mtp_kv &&
+            use_mtp_head  == other.use_mtp_head  &&
             n_outputs == other.n_outputs;
     }
 };

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -402,6 +402,7 @@ struct llm_graph_params {
     const llama_adapter_loras    * loras;
     const llama_memory_context_i * mctx;
     const llama_cross            * cross;
+    bool update_mtp_kv;
 
     uint32_t n_outputs;
 

--- a/src/llama-kv-cache-unified.cpp
+++ b/src/llama-kv-cache-unified.cpp
@@ -766,7 +766,6 @@ bool llama_kv_cache_unified::update(llama_context * lctx, bool do_shift, const d
 }
 
 llama_kv_cache_unified::slot_info llama_kv_cache_unified::find_slot(const llama_ubatch & ubatch, bool cont) const {
-    LLAMA_LOG_WARN("%s: Entering find_slot for ubatch of %d tokens.\n", __func__, ubatch.n_tokens);
     if (debug > 0) {
         const auto & cells = v_cells[seq_to_stream[1]];
 
@@ -972,9 +971,6 @@ llama_kv_cache_unified::slot_info llama_kv_cache_unified::find_slot(const llama_
                 }
             }
         }
-        LLAMA_LOG_WARN("%s: find_slot SUCCEEDED for ubatch of %d tokens. Idxs:%s\n", __func__, ubatch.n_tokens, idxs_str.c_str());
-    } else {
-        LLAMA_LOG_ERROR("%s: find_slot FAILED to allocate cells for ubatch of %d tokens.\n", __func__, ubatch.n_tokens);
     }
 
     return res;

--- a/src/llama-kv-cache-unified.h
+++ b/src/llama-kv-cache-unified.h
@@ -116,6 +116,12 @@ public:
             llama_batch_allocr & balloc,
             uint32_t n_ubatch,
             bool embd_all) override;
+    
+    llama_memory_context_ptr init_batch_with_sinfos(
+            llama_batch_allocr & balloc,
+            uint32_t n_ubatch,
+            const slot_info_vec_t & sinfos,
+            bool is_inplace_update);
 
     llama_memory_context_ptr init_full() override;
 
@@ -181,7 +187,7 @@ public:
     slot_info find_slot(const llama_ubatch & ubatch, bool cont) const;
 
     // emplace the ubatch context into slot: [sinfo.idxs[0...ubatch.n_tokens - 1]]
-    void apply_ubatch(const slot_info & sinfo, const llama_ubatch & ubatch);
+    void apply_ubatch(const slot_info & sinfo, const llama_ubatch & ubatch, bool is_inplace_update = false);
 
     //
     // input API
@@ -321,7 +327,8 @@ public:
     llama_kv_cache_unified_context(
             llama_kv_cache_unified * kv,
             slot_info_vec_t sinfos,
-            std::vector<llama_ubatch> ubatches);
+            std::vector<llama_ubatch> ubatches,
+            bool is_inplace_update = false);
 
     virtual ~llama_kv_cache_unified_context();
 
@@ -365,6 +372,8 @@ public:
 
     void set_sinfos(slot_info_vec_t new_sinfos);
 
+    const slot_info_vec_t & get_sinfos() const { return sinfos; }
+
 private:
     llama_memory_status status;
 
@@ -399,4 +408,6 @@ private:
     // a heuristic, to avoid attending the full cache if it is not yet utilized
     // as the cache gets filled, the benefit from this heuristic disappears
     int32_t n_kv;
+
+    bool is_inplace_update = false;
 };

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -13788,6 +13788,13 @@ struct llm_build_glm4 : public llm_graph_context {
 
 struct llm_build_glm4_moe : public llm_graph_context {
     llm_build_glm4_moe(const llama_model & model, const llm_graph_params & params) : llm_graph_context(params) {
+        LLAMA_LOG_WARN(
+            "[GRAPH_BUILD] Building graph. Path: %s, MTP_Update: %s, UBatch_Tokens: %d, First_Pos: %d\n",
+            params.use_mtp_head ? "MTP" : "MAIN",
+            params.update_mtp_kv ? "true" : "false",
+            n_tokens,
+            n_tokens > 0 ? ubatch.pos[0] : -1
+        );
         const int64_t n_embd_head = hparams.n_embd_head_v;
         GGML_ASSERT(n_embd_head == hparams.n_embd_head_k);
 
@@ -13906,7 +13913,10 @@ struct llm_build_glm4_moe : public llm_graph_context {
                     cb(Qcur, "Qcur", il);
                     cb(Kcur, "Kcur", il);
                     cb(Vcur, "Vcur", il);
-
+                    if (ubatch.n_tokens > 0) {
+                        LLAMA_LOG_WARN("[KV_WRITE] path=MAIN, layer=%d, n_tokens=%d, pos_start=%d, pos_end=%d\n",
+                            il, ubatch.n_tokens, ubatch.pos[0], ubatch.pos[ubatch.n_tokens-1]);
+                    }
                     cur = build_attn(inp_attn,
                             model.layers[il].wo, NULL,
                             Qcur, Kcur, Vcur, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
@@ -14060,7 +14070,10 @@ private:
             // LLAMA_LOG_WARN("  - Qcur shape: [%d, %d, %d]\n", Qcur->ne[0], Qcur->ne[1], Qcur->ne[2]);
             // LLAMA_LOG_WARN("  - Kcur shape: [%d, %d, %d]\n", Kcur->ne[0], Kcur->ne[1], Kcur->ne[2]);
             // LLAMA_LOG_WARN("  - Vcur shape: [%d, %d, %d]\n", Vcur->ne[0], Vcur->ne[1], Vcur->ne[2]);
-
+            if (ubatch.n_tokens > 0) {
+                LLAMA_LOG_WARN("[KV_WRITE] path=MTP, layer=%d, n_tokens=%d, pos_start=%d, pos_end=%d\n",
+                    il, ubatch.n_tokens, ubatch.pos[0], ubatch.pos[ubatch.n_tokens-1]);
+            }
             cur = build_attn(inp_attn,
                      mtp_layer.wo, NULL,
                      Qcur, Kcur, Vcur, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -13829,11 +13829,6 @@ struct llm_build_glm4_moe : public llm_graph_context {
             // Final layer tensors are loaded but not processed in forward pass
             const int n_transformer_layers = n_layer - hparams.nextn_predict_layers;
             for (int il = 0; il < n_transformer_layers; ++il) {
-                // if (params.use_mtp_head) {
-                //     LLAMA_LOG_ERROR("[DEBUG-KV-ERROR] MTP path is running the main layer %d!\n", il);
-                // } else {
-                //     LLAMA_LOG_WARN("[DEBUG-KV] Main Head Path: Accessing layer %d\n", il);
-                // }
                 ggml_tensor * inpSA = inpL;
 
                 // Pre-attention norm
@@ -13976,7 +13971,6 @@ private:
         ggml_tensor * embd_copy = ggml_dup(ctx0, prev_embeddings);
 
         const int il = hparams.n_layer - 1;
-        // LLAMA_LOG_WARN("[DEBUG-KV] MTP Head Path: Accessing layer %d\n", il);
         ggml_tensor * sum_node = ggml_sum(ctx0, embd_copy);
 
         ggml_set_name(sum_node, "mtp_input_sum");
@@ -18311,12 +18305,8 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
 }
 
 ggml_cgraph * llama_model::build_graph(const llm_graph_params & params) const {
-    const int64_t t_start_us = ggml_time_us();
     
     std::unique_ptr<llm_graph_context> llm;
-
-    const bool build_mtp = params.mtp_params.op_type == MTP_OP_UPDATE_ACCEPTED;
-
     switch (arch) {
         case LLM_ARCH_LLAMA:
             {
@@ -18678,12 +18668,6 @@ ggml_cgraph * llama_model::build_graph(const llm_graph_params & params) const {
         // add on pooling layer
         llm->build_pooling(cls, cls_b, cls_out, cls_out_b);
     }
-    const int64_t t_end_us = ggml_time_us();
-    // LLAMA_LOG_INFO(
-    //     "[PERF] Graph build time: %.2f ms (MTP path: %s)\n",
-    //     (t_end_us - t_start_us) / 1000.0,
-    //     params.use_mtp_head ? "yes" : "no"
-    // );
     return llm->res->get_gf();
 }
 

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -475,7 +475,6 @@ struct llama_model {
 
     // TODO: move this to new llm_arch_model_i interface
     ggml_cgraph * build_graph(const llm_graph_params & params) const;
-    ggml_cgraph * build_mtp_graph(const llm_graph_params& params) const;
 
 private:
     struct impl;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -475,8 +475,7 @@ struct llama_model {
 
     // TODO: move this to new llm_arch_model_i interface
     ggml_cgraph * build_graph(const llm_graph_params & params) const;
-    ggml_cgraph * build_mtp_graph(const llm_graph_params & params,
-        llama_token last_token_id, int n_past) const;
+    ggml_cgraph * build_mtp_graph(const llm_graph_params& params) const;
 
 private:
     struct impl;

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -3520,11 +3520,10 @@ struct server_context {
                     needs_mtp_warmup = true;
                 }
             }
-
+            
             if (needs_mtp_warmup) {
-                if (llama_mtp_prepare_sinfo_for_update(ctx, batch_view.n_tokens)) {
+                if (llama_mtp_prepare_sinfo_for_warmup(ctx)) {
                     mtp_update_kv_cache(ctx, batch_view, true);
-
                     llama_mtp_cancel_sinfo_update(ctx);
                 } else {
                     LOG_ERR("%s: Failed to prepare the MTP symphony for warmup.", __func__);

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -3387,6 +3387,15 @@ struct server_context {
                         slot.n_prompt_tokens_processed += n_pos;
                     }
 
+                    const size_t n_to_log = slot.mtp_kv_update_batch.size();
+                    if (n_to_log > 0) {
+                        SLT_INF(slot,
+                            "DEBUG-KV-REQ Cache Warm-up: Requesting KV update for %zu tokens. Positions: %d ... %d\n",
+                            n_to_log,
+                            slot.mtp_kv_update_batch.front().n_past,
+                            slot.mtp_kv_update_batch.back().n_past
+                        );
+                    }
                     // add prompt tokens for processing in the current batch
                     while (slot.n_past < slot.n_prompt_tokens && batch.n_tokens < n_batch) {
                         // get next token to process
@@ -3517,12 +3526,12 @@ struct server_context {
                 continue; // continue loop of n_batch
             }
 
-            for (auto & slot : slots) {
-                // This should only trigger on a non-empty update batch once, after prompt processing but not during token generation
-                if (slot.has_mtp) {
-                    mtp_update_kv_cache(ctx, slot.mtp_kv_update_batch, i, n_tokens);
-               }
-            }
+            // for (auto & slot : slots) {
+            //     // This should only trigger on a non-empty update batch once, after prompt processing but not during token generation
+            //     if (slot.has_mtp) {
+            //         mtp_update_kv_cache(ctx, slot.mtp_kv_update_batch, i, n_tokens);
+            //    }
+            // }
 
             // move the head of the batch forward with the number of tokens we just processed
             i_next = i + n_tokens;

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -1739,7 +1739,7 @@ struct server_queue {
 
         while (true) {
             QUE_DBG("%s", "processing new tasks\n");
-
+            const int64_t t_turn_start_us = ggml_time_us();
             while (true) {
                 std::unique_lock<std::mutex> lock(mutex_tasks);
                 if (!running) {
@@ -1762,7 +1762,11 @@ struct server_queue {
             QUE_DBG("%s", "update slots\n");
 
             callback_update_slots();
-
+            const int64_t t_turn_end_us = ggml_time_us();
+            SRV_DBG(
+                "[PERF] Server turn time: %.2f ms\n",
+                (t_turn_end_us - t_turn_start_us) / 1000.0
+            );
             QUE_DBG("%s", "waiting for new tasks\n");
             {
                 std::unique_lock<std::mutex> lock(mutex_tasks);

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -3520,7 +3520,7 @@ struct server_context {
                     // Clean up the forced state to not affect subsequent decodes.
                     llama_mtp_cancel_sinfo_update(ctx);
                 } else {
-                    LOG_ERR("%s: Failed to prepare the MTP symphony for warmup.", __func__);
+                    LOG_ERR("%s: Failed to prepare the MTP for warmup.", __func__);
                 }
             }
 


### PR DESCRIPTION
For now, this is a proof of concept for batching the MTP KV cache update. My approach was to unify all MTP-related graph execution into the main `llama_decode` function, which already handles batching and ubatching efficiently.

The performance is currently not ideal, and my guess is that it's due to the overhead of building and executing the full, combined graph every time `decode` is called, especially since we now use it for both KV cache updates and single-token draft generation.

From here, I was thinking of two main options to optimize this:

1.  Work more inside `llama_decode` to make the unified graph approach more efficient. This would mean investigating why the graph cache isn't being reused and finding ways to avoid redundant computations when we only need the MTP-specific part of the graph.
2.  Create a separate `llama_decode_mtp` function. This would be a stripped-down version of `decode` dedicated to running only the MTP graph. This would likely require creating several new helper functions to be shared between both decode paths to avoid too much code duplication.

I'm more inclined towards the first option for the long run. As more models adopt MTP, it seems better to have a single, unified `decode` path that can handle it, rather than maintaining two separate ones.

Still, I'm not completely sure which path is best, so I wanted to share this draft to open a discussion, while I continue to work on ideas to optimize the unified graph approach.