### PR TITLE
Glm4 mtp optimizations

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -348,6 +348,11 @@ llama_token common_sampler_sample(struct common_sampler * gsmpl, struct llama_co
 
     llama_sampler_apply(chain, &cur_p);
 
+    /*for (int k = 0; k < (int)cur_p.size; ++k) {
+        LOG_INF(" - draft candidate %3d, pos %3d: %6d (%8.3f)\n",
+            k, 0, cur_p.data[k].id, cur_p.data[k].p);
+    }*/
+
     GGML_ASSERT(cur_p.selected != -1 && "no selected token during sampling - check your sampling configuration");
 
     const llama_token id = cur_p.data[cur_p.selected].id;

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -582,3 +582,7 @@ std::vector<common_sampler_type> common_sampler_types_from_chars(const std::stri
 
     return samplers;
 }
+
+void common_sampler_apply_chain(struct common_sampler * gsmpl, struct llama_token_data_array * cur_p) {
+    llama_sampler_apply(gsmpl->chain, cur_p);
+}

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -105,3 +105,5 @@ std::vector<enum common_sampler_type> common_sampler_types_from_chars(const std:
 
 llama_sampler * llama_sampler_init_llg(const llama_vocab * vocab,
                 const char * grammar_kind, const char * grammar_data);
+
+void common_sampler_apply_chain(struct common_sampler * gsmpl, struct llama_token_data_array * cur_p);

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -370,56 +370,20 @@ llama_token mtp_speculative_gen_draft(
     int32_t n_past,
     int32_t last_tok_idx) {
 
-    llama_token token_data[] = { id_last };
-    llama_pos pos_data[] = { n_past };
-    int32_t n_seq_id_data[] = { 1 };
-    llama_seq_id seq_id_data_internal[] = { 0 };
-    llama_seq_id* seq_id_data[] = {seq_id_data_internal};
-    int8_t logits_data[] = { (int8_t) (smpl != nullptr) };
-
-    llama_batch batch = {
-        /*.n_tokens = */    1,
-        /*.token = */       token_data,
-        /*.embd = */        nullptr,
-        /*.pos = */         pos_data,
-        /*.n_seq_id = */    n_seq_id_data,
-        /*.seq_id = */      seq_id_data,
-        /*.logits = */      logits_data
-    };
-
-    return llama_build_and_execute_mtp_graph(ctx, batch, id_last, n_past, last_tok_idx);
-    //LOG_INF("updating kv cache for n_past: %d\n", n_past);
-
-    /*
     if (!smpl) {
         return -1;
     }
-    else {
-        common_sampler_sample(smpl, ctx, last_tok_idx, true);
-        const auto* cur_p = common_sampler_get_candidates(smpl);
 
-        //for (int k = 0; k < std::min(3, (int)cur_p->size); ++k) {
-        //    LOG_INF(" - draft candidate %3d, pos %3d: %6d (%8.3f) '%s'\n",
-        //        k, 0, cur_p->data[k].id, cur_p->data[k].p, common_token_to_piece(ctx, cur_p->data[k].id).c_str());
-        //}
+    llama_batch batch = llama_batch_init(1, 0, 1);
+    common_batch_add(batch, id_last, n_past, {0}, true);
 
-        const llama_token id = cur_p->data[0].id;
-        return id;
-    }
-    */
-    // LOG_INF("cur_p->size: %d\n", cur_p->size);
+    llama_build_and_execute_mtp_graph(ctx, batch, id_last, n_past, last_tok_idx);
 
+    llama_token id = common_sampler_sample(smpl, ctx, last_tok_idx, true);
 
-    // add drafted token for each sequence
+    llama_batch_free(batch);
 
-    // skip accepting draft token -- since we're only drafting one token this can't affect future outputs
-    // smpl will accept the token if it doesn't get rejected by main model later
-    // common_sampler_accept(smpl, id, true);
-
-    //llama_tokens result;
-    //result.reserve(1);
-    //result.push_back(id);
-    //return result;
+    return id;
 }
 
 

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -436,10 +436,13 @@ void mtp_accept_tokens(
         return;
     }
 
+    // Prepare a resized copy of the validation sinfo to match the number of accepted tokens.
+    //    This sets up the context for a "forced sinfo" decode.
     if (!llama_mtp_prepare_sinfo_for_update(ctx, ids.size())) {
         return;
     }
 
+    // Build a new batch containing only the accepted tokens.
     llama_batch accepted_batch = llama_batch_init(ids.size(), 0, 1);
     for (size_t i = 0; i < ids.size(); ++i) {
         common_batch_add(accepted_batch, ids[i], n_past_base + i, { seq_id }, true);
@@ -447,6 +450,7 @@ void mtp_accept_tokens(
 
     mtp_update_kv_cache(ctx, accepted_batch, false);
 
+    // Clean up the forced state to not affect subsequent, normal decode calls.
     llama_mtp_cancel_sinfo_update(ctx);
 
     llama_batch_free(accepted_batch);

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -374,6 +374,8 @@ llama_token mtp_speculative_gen_draft(
         return -1;
     }
     llama_batch mtp_batch = llama_batch_init(1, 0, 1);
+    const llama_pos draft_pos = n_past;
+    const llama_seq_id draft_seq_id = 0;
     common_batch_add(mtp_batch, id_last, n_past, {0}, true);
 
     mtp_batch.update_mtp_kv = false;
@@ -386,6 +388,8 @@ llama_token mtp_speculative_gen_draft(
 
     llama_decode(ctx, mtp_batch);
     llama_batch_free(mtp_batch);
+
+    llama_kv_cache_seq_rm(ctx, draft_seq_id, draft_pos, draft_pos + 1);
 
     const llama_model * model = llama_get_model(ctx);
     const llama_vocab * vocab = llama_model_get_vocab(model);

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -423,11 +423,18 @@ llama_token mtp_speculative_gen_draft(
 }
 
 
-void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens) {
+void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens, size_t batch_start, size_t n_tokens) {
     mtp_kv_update_data token;
-    for (int i = 0; i < tokens.size(); ++i) {
+
+    if (n_tokens < 0) {
+        n_tokens = tokens.size();
+    }
+
+    for (int i = 0; i < std::min(tokens.size(), n_tokens); ++i) {
         token = tokens[i];
-        mtp_speculative_gen_draft(nullptr, ctx, token.id, token.n_past, token.tok_idx);
+        //fprintf(stderr, "updating mtp kv cache with token  (%d, %d, %d)\n", token.id, token.n_past, (int) (token.tok_idx - batch_start));
+
+        mtp_speculative_gen_draft(nullptr, ctx, token.id, token.n_past, token.tok_idx - batch_start);
     }
 
     tokens.clear();

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -387,9 +387,10 @@ llama_token mtp_speculative_gen_draft(
         /*.logits = */      logits_data
     };
 
-    llama_build_and_execute_mtp_graph(ctx, batch, id_last, n_past, last_tok_idx);
+    return llama_build_and_execute_mtp_graph(ctx, batch, id_last, n_past, last_tok_idx);
     //LOG_INF("updating kv cache for n_past: %d\n", n_past);
 
+    /*
     if (!smpl) {
         return -1;
     }
@@ -405,6 +406,7 @@ llama_token mtp_speculative_gen_draft(
         const llama_token id = cur_p->data[0].id;
         return id;
     }
+    */
     // LOG_INF("cur_p->size: %d\n", cur_p->size);
 
 

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -381,6 +381,14 @@ llama_token mtp_speculative_gen_draft(
 
     llama_token id = common_sampler_sample(smpl, ctx, last_tok_idx, true);
 
+    const auto * cur_p = common_sampler_get_candidates(smpl);
+    for (int k = 0; k < std::min(3, (int)cur_p->size); ++k) {
+        LOG_DBG(" - draft candidate %3d, pos %3d: %6d (%8.3f) '%s'\n",
+            k, 0, cur_p->data[k].id, cur_p->data[k].p, common_token_to_piece(ctx, cur_p->data[k].id).c_str());
+    }
+
+    common_sampler_accept(smpl, id, true);
+
     llama_batch_free(batch);
 
     return id;

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -5,6 +5,7 @@
 #include "log.h"
 #include "common.h"
 #include "sampling.h"
+#include "../src/llama-graph.h"
 
 #include <cstring>
 #include <algorithm>
@@ -357,5 +358,130 @@ llama_tokens common_speculative_gen_draft(
             result.resize(params.n_draft);
         }
     }
+    return result;
+}
+
+
+llama_tokens mtp_speculative_gen_draft(
+        struct common_sampler * smpl,
+        struct llama_context * ctx,
+        llama_token id_last,
+        int32_t n_past,
+        int32_t last_tok_idx) {
+
+    llama_tokens result;
+
+    LOG_INF("step: '%d'\n", 1);
+
+    // sample one token from the draft model -- this does NOT generalize to >1 MTP head
+    result.reserve(1);
+
+    // need to determine which architecture we're using so we call the correct MTP model
+    const auto * model = llama_get_model(ctx);
+
+    LOG_INF("step: '%d'\n", 2);
+
+    //LLAMA_LOG_INFO("graph build time: %.3f ms\n", (ggml_time_us() - t_start_us)/1000.0);
+    //auto * gf = model.build_graph(gparams);
+
+    LOG_INF("step: '%d'\n", 3);
+
+    /*if (!ggml_backend_sched_alloc_graph(sched.get(), gf)) {
+        LLAMA_LOG_ERROR("%s: failed to allocate graph\n", __func__);
+        ret = GGML_STATUS_ALLOC_FAILED;
+        return nullptr;
+    }*/
+
+    //llm_graph_result res_mtp(ctx->graph_max_nodes());
+    llm_graph_result * res_mtp;
+    llama_ubatch ubatch_mtp;
+    ubatch_mtp.n_tokens = 1;
+    ubatch_mtp.pos = &n_past; // Critical for positional encoding
+
+    // We also need a minimal ubatch to provide positional context (RoPE)
+    // ubatch_mtp.tokens = &last_token_id;
+    // ubatch_mtp.seq_id = llama_get_main_seq_id(ctx); // Assuming a helper
+    // ubatch_mtp.logits = nullptr;
+    // ubatch_mtp.all_pos_0 = -1;
+    // ubatch_mtp.all_pos_1 = -1;
+    // ubatch_mtp.all_seq_id = -1;
+
+    // Manually construct the graph parameters
+    //const llm_graph_params params_mtp = {
+    //    /*.arch        =*/ model->arch,
+    //    /*.hparams     =*/ model->hparams,
+    //    /*.cparams     =*/ ctx->cparams,
+    //    /*.ubatch      =*/ ubatch_mtp,
+    //    /*.gtype       =*/ LLM_GRAPH_TYPE_DECODER,
+    //    /*.sched       =*/ ctx->sched.get(),
+    //    /*.backend_cpu =*/ ctx->backend_cpu,
+    //    /*.cvec        =*/ &ctx->cvec,
+    //    /*.loras       =*/ &ctx->loras,
+    //    /*.mctx        =*/ llama_get_memory(ctx), // Use the KV cache's memory context
+    //    /*.cross       =*/ &ctx->cross,
+    //    /*.n_outputs   =*/ 1,
+    //    /*.cb          =*/ ctx->graph_get_cb(),
+    //    /*.res         =*/ &res_mtp, // Point to our temporary result object
+    //};
+    llm_graph_params params_mtp = llama_mtp_graph_params(ctx, res_mtp, ubatch_mtp);
+
+    LOG_INF("step: '%d'\n", 4);
+
+    // ggml_cgraph* build_mtp_graph(const llm_graph_params & params,
+    //     ggml_tensor * hidden_state_inp, llama_token last_token_id, int n_past) const;
+    auto * last_embd = llama_get_embeddings_tensor(ctx);
+
+    LOG_INF("step: '%d'\n", 5);
+
+    GGML_ASSERT(model != nullptr);
+    GGML_ASSERT(last_embd != nullptr);
+
+    auto * gf = llama_build_mtp_graph(model, params_mtp, last_embd, id_last, n_past);
+
+    if (!gf) {
+        LOG_INF("%s: failed to initialize graph\n", __func__);
+        //ret = GGML_STATUS_FAILED;
+        return result;
+    }
+
+    LOG_INF("step: '%d'\n", 6);
+
+    const auto status = llama_graph_compute(ctx, gf, false);
+
+    LOG_INF("step: '%d'\n", 7);
+
+    struct ggml_tensor * logits_mtp = llama_graph_result_get_logits(res_mtp);
+    float * ctx_logit_pointer = llama_get_logits(ctx);
+
+    LOG_INF("step: '%d'\n", 8);
+
+    if (logits_mtp) {
+        llama_set_logits(ctx, logits_mtp);
+    }
+
+    LOG_INF("step: '%d'\n", 9);
+
+    {
+        common_sampler_sample(smpl, ctx, last_tok_idx, true);
+
+        LOG_INF("step: '%d'\n", 10);
+
+        const auto * cur_p = common_sampler_get_candidates(smpl);
+
+        for (int k = 0; k < std::min(3, (int) cur_p->size); ++k) {
+            LOG_INF(" - draft candidate %3d, pos %3d: %6d (%8.3f) '%s'\n",
+                    k, 0, cur_p->data[k].id, cur_p->data[k].p, common_token_to_piece(ctx, cur_p->data[k].id).c_str());
+        }
+
+        // add drafted token for each sequence
+        const llama_token id = cur_p->data[0].id;
+
+        // skip accepting draft token -- since we're only drafting one token this can't affect future outputs
+        // smpl will accept the token if it doesn't get rejected by main model later
+        // common_sampler_accept(smpl, id, true);
+
+        result.push_back(id);
+    }
+
     return result;
 }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -378,7 +378,7 @@ llama_token mtp_speculative_gen_draft(
     const llama_seq_id draft_seq_id = 0;
     common_batch_add(mtp_batch, id_last, n_past, {0}, true);
 
-    mtp_batch.mtp_params.op_type = MTP_OP_DRAFT_GEN;
+    mtp_batch.mtp_params.op_type = MTP_OP_DRAFT_ONLY;
 
     // Perform the MTP draft generation decode. This writes the MTP layer's
     // KV state for the draft token into the cache.
@@ -406,58 +406,4 @@ llama_token mtp_speculative_gen_draft(
     common_sampler_apply_chain(smpl, cur_p);
     
     return cur_p->data[0].id;
-}
-
-
-void mtp_update_kv_cache(struct llama_context * ctx, const llama_batch& batch, bool is_prompt_warmup) {
-    if (batch.n_tokens == 0) {
-        return;
-    }
-
-    LOG_DBG("[MTP-UPDATE|%s] Updating %d tokens...\n", is_prompt_warmup ? "PROMPT_WARMUP" : "GEN_ACCEPTED", batch.n_tokens);
-
-    llama_batch mtp_batch = batch;
-    if (is_prompt_warmup) {
-        mtp_batch.mtp_params.op_type = MTP_OP_WARMUP;
-    } else {
-        mtp_batch.mtp_params.op_type = MTP_OP_UPDATE_ACCEPTED;
-    }
-
-    for (int i = 0; i < mtp_batch.n_tokens; ++i) {
-        mtp_batch.logits[i] = true;
-    }
-    const int64_t t_start_us = ggml_time_us();
-    llama_decode(ctx, mtp_batch);
-    const int64_t t_end_us = ggml_time_us();
-    LOG_INF("[PERF-MTP] mtp_update_kv_cache internal decode (op=%d): %.2f ms\n", (int)mtp_batch.mtp_params.op_type, (t_end_us - t_start_us) / 1000.0);
-}
-
-void mtp_accept_tokens(
-    struct llama_context * ctx,
-    const std::vector<llama_token> & ids,
-    int32_t n_past_base,
-    llama_seq_id seq_id
-) {
-    if (ids.empty()) {
-        return;
-    }
-
-    // Prepare a resized copy of the validation sinfo to match the number of accepted tokens.
-    //    This sets up the context for a "forced sinfo" decode.
-    if (!llama_mtp_prepare_sinfo_for_update(ctx, ids.size())) {
-        return;
-    }
-
-    // Build a new batch containing only the accepted tokens.
-    llama_batch accepted_batch = llama_batch_init(ids.size(), 0, 1);
-    for (size_t i = 0; i < ids.size(); ++i) {
-        common_batch_add(accepted_batch, ids[i], n_past_base + i, { seq_id }, true);
-    }
-
-    mtp_update_kv_cache(ctx, accepted_batch, false);
-
-    // Clean up the forced state to not affect subsequent, normal decode calls.
-    llama_mtp_cancel_sinfo_update(ctx);
-
-    llama_batch_free(accepted_batch);
 }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -382,7 +382,10 @@ llama_token mtp_speculative_gen_draft(
 
     // Perform the MTP draft generation decode. This writes the MTP layer's
     // KV state for the draft token into the cache.
+    const int64_t t_start_us = ggml_time_us();
     llama_decode(ctx, mtp_batch);
+    const int64_t t_end_us = ggml_time_us();
+    LOG_INF("[PERF-MTP] mtp_speculative_gen_draft internal decode: %.2f ms\n", (t_end_us - t_start_us) / 1000.0);
     llama_batch_free(mtp_batch);
 
     // CRITICAL: Purge the metadata for the draft token we just wrote.
@@ -423,7 +426,10 @@ void mtp_update_kv_cache(struct llama_context * ctx, const llama_batch& batch, b
     for (int i = 0; i < mtp_batch.n_tokens; ++i) {
         mtp_batch.logits[i] = true;
     }
+    const int64_t t_start_us = ggml_time_us();
     llama_decode(ctx, mtp_batch);
+    const int64_t t_end_us = ggml_time_us();
+    LOG_INF("[PERF-MTP] mtp_update_kv_cache internal decode (op=%d): %.2f ms\n", (int)mtp_batch.mtp_params.op_type, (t_end_us - t_start_us) / 1000.0);
 }
 
 void mtp_accept_tokens(

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -374,7 +374,6 @@ llama_token mtp_speculative_gen_draft(
         return -1;
     }
     llama_batch mtp_batch = llama_batch_init(1, 0, 1);
-    const llama_pos draft_pos = n_past;
     const llama_seq_id draft_seq_id = 0;
     common_batch_add(mtp_batch, id_last, n_past, {0}, true);
 
@@ -383,7 +382,10 @@ llama_token mtp_speculative_gen_draft(
     // Perform the MTP draft generation decode. This writes the MTP layer's
     // KV state for the draft token into the cache.
     const int64_t t_start_us = ggml_time_us();
-    llama_decode(ctx, mtp_batch);
+    if (llama_decode(ctx, mtp_batch) != 0) {
+        llama_batch_free(mtp_batch);
+        return -1;
+    }
     const int64_t t_end_us = ggml_time_us();
     LOG_INF("[PERF-MTP] mtp_speculative_gen_draft internal decode: %.2f ms\n", (t_end_us - t_start_us) / 1000.0);
     llama_batch_free(mtp_batch);
@@ -391,17 +393,21 @@ llama_token mtp_speculative_gen_draft(
     // CRITICAL: Purge the metadata for the draft token we just wrote.
     // This makes the physical cell available again for the main model's validation pass,
     // preventing a cache state corruption where two cells map to the same logical position.
-    llama_kv_cache_seq_rm(ctx, draft_seq_id, draft_pos, draft_pos + 1);
+    llama_kv_cache_seq_rm(ctx, draft_seq_id, n_past, n_past + 1);
 
     const llama_model * model = llama_get_model(ctx);
     const llama_vocab * vocab = llama_model_get_vocab(model);
     const int n_vocab = llama_n_vocab(vocab);
+
     llama_token_data_array * cur_p = common_sampler_get_candidates(smpl);
+    float * logits = llama_get_logits_ith(ctx, 0);
     cur_p->size = n_vocab;
+
     for (int i = 0; i < n_vocab; ++i) {
         cur_p->data[i].id = i;
-        cur_p->data[i].logit = llama_get_logits_ith(ctx, 0)[i]; // For a single-token batch, logits are always at index 0.
+        cur_p->data[i].logit = logits[i];
     }
+
     cur_p->sorted = false;
     common_sampler_apply_chain(smpl, cur_p);
     

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -49,7 +49,6 @@ llama_tokens common_speculative_gen_draft(
     const llama_tokens & prompt,
     llama_token   id_last);
 
-void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens, 
-                        bool is_prompt_warmup);
+void mtp_update_kv_cache(struct llama_context * ctx, const llama_batch& batch, bool is_prompt_warmup);
 
 double calculate_vector_sum_double(const float* vec, size_t size);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -44,9 +44,9 @@ llama_token mtp_speculative_gen_draft(
 
 // sample up to n_draft tokens and add them to the batch using the draft model
 llama_tokens common_speculative_gen_draft(
-               struct common_speculative * spec,
-        struct common_speculative_params   params,
-                      const llama_tokens & prompt,
-                             llama_token   id_last);
+    struct common_speculative * spec,
+    struct common_speculative_params   params,
+    const llama_tokens & prompt,
+    llama_token   id_last);
 
 void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens, size_t batch_start = 0, size_t n_tokens = -1);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -49,4 +49,4 @@ llama_tokens common_speculative_gen_draft(
     const llama_tokens & prompt,
     llama_token   id_last);
 
-void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens, size_t batch_start = 0, size_t n_tokens = -1);
+void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -49,4 +49,7 @@ llama_tokens common_speculative_gen_draft(
     const llama_tokens & prompt,
     llama_token   id_last);
 
-void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens, const char* tag);
+void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens, 
+                        bool is_prompt_warmup);
+
+double calculate_vector_sum_double(const float* vec, size_t size);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -49,4 +49,4 @@ llama_tokens common_speculative_gen_draft(
     const llama_tokens & prompt,
     llama_token   id_last);
 
-void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens);
+void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens, const char* tag);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -51,4 +51,11 @@ llama_tokens common_speculative_gen_draft(
 
 void mtp_update_kv_cache(struct llama_context * ctx, const llama_batch& batch, bool is_prompt_warmup);
 
+void mtp_accept_tokens(
+    struct llama_context * ctx,
+    const std::vector<llama_token> & ids,
+    int32_t n_past_base,
+    llama_seq_id seq_id
+);
+
 double calculate_vector_sum_double(const float* vec, size_t size);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -49,4 +49,4 @@ llama_tokens common_speculative_gen_draft(
                       const llama_tokens & prompt,
                              llama_token   id_last);
 
-void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens);
+void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens, size_t batch_start = 0, size_t n_tokens = -1);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -57,5 +57,3 @@ void mtp_accept_tokens(
     int32_t n_past_base,
     llama_seq_id seq_id
 );
-
-double calculate_vector_sum_double(const float* vec, size_t size);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -29,7 +29,7 @@ void common_speculative_add_replacement_tgt_dft(
 
 
 // sample up to n_draft tokens and add them to the batch using the draft model
-llama_tokens mtp_speculative_gen_draft(
+llama_token mtp_speculative_gen_draft(
     struct common_sampler* smpl,
     struct llama_context* ctx,
     llama_token id_last,

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -27,6 +27,15 @@ void common_speculative_add_replacement_tgt_dft(
         struct common_speculative * spec,
         const char *source, const char *dest);
 
+
+// sample up to n_draft tokens and add them to the batch using the draft model
+llama_tokens mtp_speculative_gen_draft(
+    struct common_sampler* smpl,
+    struct llama_context* ctx,
+    llama_token id_last,
+    int32_t n_past,
+    int32_t last_tok_idx);
+
 // sample up to n_draft tokens and add them to the batch using the draft model
 llama_tokens common_speculative_gen_draft(
                struct common_speculative * spec,

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -12,6 +12,12 @@ struct common_speculative_params {
     float p_min = 0.75f; // min probability required to accept a token in the draft
 };
 
+struct mtp_kv_update_data {
+    llama_token id;
+    int32_t n_past;
+    int32_t tok_idx;
+};
+
 struct common_speculative * common_speculative_init(
         struct llama_context * ctx_tgt,
         struct llama_context * ctx_dft
@@ -42,3 +48,5 @@ llama_tokens common_speculative_gen_draft(
         struct common_speculative_params   params,
                       const llama_tokens & prompt,
                              llama_token   id_last);
+
+void mtp_update_kv_cache(struct llama_context * ctx, std::vector<mtp_kv_update_data>& tokens);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -48,12 +48,3 @@ llama_tokens common_speculative_gen_draft(
     struct common_speculative_params   params,
     const llama_tokens & prompt,
     llama_token   id_last);
-
-void mtp_update_kv_cache(struct llama_context * ctx, const llama_batch& batch, bool is_prompt_warmup);
-
-void mtp_accept_tokens(
-    struct llama_context * ctx,
-    const std::vector<llama_token> & ids,
-    int32_t n_past_base,
-    llama_seq_id seq_id
-);

--- a/include/llama.h
+++ b/include/llama.h
@@ -1466,14 +1466,36 @@ extern "C" {
             ggml_opt_epoch_callback   callback_train,
             ggml_opt_epoch_callback   callback_eval);
 
+    //
+    // MTP
+    //
+
     LLAMA_API void llama_set_draft_input_hidden_state(struct llama_context * ctx, const float * hidden_state);
 
+    /**
+     * @brief Prepares the context for an MTP KV cache update by creating a resized copy of the last sinfo.
+     *        This is used after speculative validation when only a subset of draft tokens are accepted.
+     * @param n_accepted The number of tokens that were accepted and for which the sinfo should be resized.
+     * @return true on success.
+     */
     LLAMA_API bool llama_mtp_prepare_sinfo_for_update(struct llama_context * ctx, size_t n_accepted);
     
+    /**
+     * @brief Prepares the context for an MTP KV cache update by reusing the sinfo from the last main model decode.
+     *        This is used for the prompt warmup to ensure the MTP and main model KV caches are perfectly aligned.
+     * @return true on success.
+     */
     LLAMA_API bool llama_mtp_prepare_sinfo_for_warmup(struct llama_context * ctx);
     
+    /**
+     * @brief Clears the forced sinfo state from the context. Must be called after a decode that used a prepared sinfo.
+     */
     LLAMA_API void llama_mtp_cancel_sinfo_update(struct llama_context * ctx);
 
+    /**
+     * @brief Removes KV cache metadata for a specified sequence and token range.
+     *        This makes the physical cells logically available again without deleting the tensor data.
+     */
     LLAMA_API void llama_kv_cache_seq_rm(struct llama_context * ctx, llama_seq_id seq_id, llama_pos p0, llama_pos p1);
 
 #ifdef __cplusplus

--- a/include/llama.h
+++ b/include/llama.h
@@ -1460,8 +1460,12 @@ extern "C" {
     LLAMA_API void llama_set_draft_input_hidden_state(struct llama_context * ctx, const float * hidden_state);
 
     LLAMA_API bool llama_mtp_prepare_sinfo_for_update(struct llama_context * ctx, size_t n_accepted);
-
+    
+    LLAMA_API bool llama_mtp_prepare_sinfo_for_warmup(struct llama_context * ctx);
+    
     LLAMA_API void llama_mtp_cancel_sinfo_update(struct llama_context * ctx);
+
+    LLAMA_API void llama_kv_cache_seq_rm(struct llama_context * ctx, llama_seq_id seq_id, llama_pos p0, llama_pos p1);
 
 #ifdef __cplusplus
 }

--- a/include/llama.h
+++ b/include/llama.h
@@ -230,6 +230,7 @@ extern "C" {
         int32_t      *  n_seq_id;
         llama_seq_id ** seq_id;
         int8_t       *  logits;   // TODO: rename this to "output"
+        bool update_mtp_kv; 
     } llama_batch;
 
     enum llama_model_kv_override_type {
@@ -1454,8 +1455,8 @@ extern "C" {
             ggml_opt_epoch_callback   callback_train,
             ggml_opt_epoch_callback   callback_eval);
 
-        LLAMA_API void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
-                const llama_batch batch_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx);
+        // LLAMA_API void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
+        //         const llama_batch batch_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx);
 
 #ifdef __cplusplus
 }

--- a/include/llama.h
+++ b/include/llama.h
@@ -221,6 +221,17 @@ extern "C" {
     //               - if not:        only the last token is output
     //            )
     //
+    typedef enum {
+        MTP_OP_NONE,
+        MTP_OP_WARMUP,
+        MTP_OP_UPDATE_ACCEPTED,
+        MTP_OP_DRAFT_GEN,
+    } llama_mtp_op_type;
+
+    typedef struct llama_mtp_params {
+        llama_mtp_op_type op_type;
+    } llama_mtp_params;
+
     typedef struct llama_batch {
         int32_t n_tokens;
 
@@ -230,9 +241,7 @@ extern "C" {
         int32_t      *  n_seq_id;
         llama_seq_id ** seq_id;
         int8_t       *  logits;   // TODO: rename this to "output"
-        bool            update_mtp_kv; 
-        bool            use_mtp_head;
-        bool            is_mtp_prompt_warmup;
+        llama_mtp_params mtp_params;
     } llama_batch;
 
     enum llama_model_kv_override_type {

--- a/include/llama.h
+++ b/include/llama.h
@@ -1457,7 +1457,11 @@ extern "C" {
             ggml_opt_epoch_callback   callback_train,
             ggml_opt_epoch_callback   callback_eval);
 
-        LLAMA_API void llama_set_draft_input_hidden_state(struct llama_context * ctx, const float * hidden_state);
+    LLAMA_API void llama_set_draft_input_hidden_state(struct llama_context * ctx, const float * hidden_state);
+
+    LLAMA_API bool llama_mtp_prepare_sinfo_for_update(struct llama_context * ctx, size_t n_accepted);
+
+    LLAMA_API void llama_mtp_cancel_sinfo_update(struct llama_context * ctx);
 
 #ifdef __cplusplus
 }

--- a/include/llama.h
+++ b/include/llama.h
@@ -232,6 +232,7 @@ extern "C" {
         int8_t       *  logits;   // TODO: rename this to "output"
         bool            update_mtp_kv; 
         bool            use_mtp_head;
+        bool            is_mtp_prompt_warmup;
     } llama_batch;
 
     enum llama_model_kv_override_type {

--- a/include/llama.h
+++ b/include/llama.h
@@ -1454,8 +1454,8 @@ extern "C" {
             ggml_opt_epoch_callback   callback_train,
             ggml_opt_epoch_callback   callback_eval);
 
-    LLAMA_API llama_token llama_build_and_execute_mtp_graph(struct llama_context * ctx,
-        const llama_batch batch_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx);
+        LLAMA_API void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
+                const llama_batch batch_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx);
 
 #ifdef __cplusplus
 }

--- a/include/llama.h
+++ b/include/llama.h
@@ -230,7 +230,8 @@ extern "C" {
         int32_t      *  n_seq_id;
         llama_seq_id ** seq_id;
         int8_t       *  logits;   // TODO: rename this to "output"
-        bool update_mtp_kv; 
+        bool            update_mtp_kv; 
+        bool            use_mtp_head;
     } llama_batch;
 
     enum llama_model_kv_override_type {
@@ -1455,8 +1456,7 @@ extern "C" {
             ggml_opt_epoch_callback   callback_train,
             ggml_opt_epoch_callback   callback_eval);
 
-        // LLAMA_API void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
-        //         const llama_batch batch_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx);
+        LLAMA_API void llama_set_draft_input_hidden_state(struct llama_context * ctx, const float * hidden_state);
 
 #ifdef __cplusplus
 }

--- a/include/llama.h
+++ b/include/llama.h
@@ -1454,7 +1454,7 @@ extern "C" {
             ggml_opt_epoch_callback   callback_train,
             ggml_opt_epoch_callback   callback_eval);
 
-    LLAMA_API void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
+    LLAMA_API llama_token llama_build_and_execute_mtp_graph(struct llama_context * ctx,
         const llama_batch batch_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx);
 
 #ifdef __cplusplus

--- a/include/llama.h
+++ b/include/llama.h
@@ -544,11 +544,16 @@ extern "C" {
     // Returns true if the model is diffusion-based (like LLaDA, Dream, etc.)
     LLAMA_API bool llama_model_is_diffusion(const struct llama_model * model);
 
+    LLAMA_API ggml_cgraph * llama_build_mtp_graph(const struct llama_model * model, const struct llm_graph_params & params,
+        struct ggml_tensor * hidden_state_inp, llama_token last_token_id, int n_past);
+
     // Returns 0 on success
     LLAMA_API uint32_t llama_model_quantize(
             const char * fname_inp,
             const char * fname_out,
             const llama_model_quantize_params * params);
+
+
 
     //
     // Adapters
@@ -972,6 +977,8 @@ extern "C" {
     // returns NULL for invalid ids.
     LLAMA_API float * llama_get_logits_ith(struct llama_context * ctx, int32_t i);
 
+    LLAMA_API void llama_set_logits(struct llama_context* ctx, struct ggml_tensor* logit_override);
+
     // Get all output token embeddings.
     // when pooling_type == LLAMA_POOLING_TYPE_NONE or when using a generative model,
     // the embeddings for which llama_batch.logits[i] != 0 are stored contiguously
@@ -993,6 +1000,8 @@ extern "C" {
     // when pooling_type == LLAMA_POOLING_TYPE_RANK, returns float[n_cls_out] with the rank(s) of the sequence
     // otherwise: float[n_embd] (1-dimensional)
     LLAMA_API float * llama_get_embeddings_seq(struct llama_context * ctx, llama_seq_id seq_id);
+
+    LLAMA_API ggml_tensor * llama_get_embeddings_tensor(struct llama_context * ctx);
 
     //
     // Vocab
@@ -1451,6 +1460,14 @@ extern "C" {
             int64_t                   idata_split,
             ggml_opt_epoch_callback   callback_train,
             ggml_opt_epoch_callback   callback_eval);
+
+    LLAMA_API llm_graph_params llama_mtp_graph_params(struct llama_context* ctx, class llm_graph_result * res, const struct llama_ubatch& ubatch);
+
+    LLAMA_API ggml_status llama_graph_compute(struct llama_context * ctx, struct ggml_cgraph * gf, bool batched);
+
+    LLAMA_API ggml_tensor * llama_graph_result_get_logits(class llm_graph_result * res);
+
+
 
 #ifdef __cplusplus
 }

--- a/include/llama.h
+++ b/include/llama.h
@@ -544,9 +544,6 @@ extern "C" {
     // Returns true if the model is diffusion-based (like LLaDA, Dream, etc.)
     LLAMA_API bool llama_model_is_diffusion(const struct llama_model * model);
 
-    LLAMA_API ggml_cgraph * llama_build_mtp_graph(const struct llama_model * model, const struct llm_graph_params & params,
-        struct ggml_tensor * hidden_state_inp, llama_token last_token_id, int n_past);
-
     // Returns 0 on success
     LLAMA_API uint32_t llama_model_quantize(
             const char * fname_inp,
@@ -998,8 +995,6 @@ extern "C" {
     // when pooling_type == LLAMA_POOLING_TYPE_RANK, returns float[n_cls_out] with the rank(s) of the sequence
     // otherwise: float[n_embd] (1-dimensional)
     LLAMA_API float * llama_get_embeddings_seq(struct llama_context * ctx, llama_seq_id seq_id);
-
-    LLAMA_API ggml_tensor * llama_get_embeddings_tensor(struct llama_context * ctx);
 
     //
     // Vocab
@@ -1459,16 +1454,8 @@ extern "C" {
             ggml_opt_epoch_callback   callback_train,
             ggml_opt_epoch_callback   callback_eval);
 
-    LLAMA_API llm_graph_params llama_mtp_graph_params(struct llama_context* ctx, class llm_graph_result * res, const struct llama_ubatch& ubatch);
-
-    LLAMA_API ggml_status llama_graph_compute(struct llama_context * ctx, struct ggml_cgraph * gf, bool batched);
-
     LLAMA_API void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
-        ggml_tensor* hidden_state_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx);
-
-    LLAMA_API ggml_tensor * llama_graph_result_get_logits(class llm_graph_result * res);
-
-
+        const llama_batch batch_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx);
 
 #ifdef __cplusplus
 }

--- a/include/llama.h
+++ b/include/llama.h
@@ -977,8 +977,6 @@ extern "C" {
     // returns NULL for invalid ids.
     LLAMA_API float * llama_get_logits_ith(struct llama_context * ctx, int32_t i);
 
-    LLAMA_API void llama_set_logits(struct llama_context* ctx, struct ggml_tensor* logit_override);
-
     // Get all output token embeddings.
     // when pooling_type == LLAMA_POOLING_TYPE_NONE or when using a generative model,
     // the embeddings for which llama_batch.logits[i] != 0 are stored contiguously
@@ -1464,6 +1462,9 @@ extern "C" {
     LLAMA_API llm_graph_params llama_mtp_graph_params(struct llama_context* ctx, class llm_graph_result * res, const struct llama_ubatch& ubatch);
 
     LLAMA_API ggml_status llama_graph_compute(struct llama_context * ctx, struct ggml_cgraph * gf, bool batched);
+
+    LLAMA_API void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
+        ggml_tensor* hidden_state_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx);
 
     LLAMA_API ggml_tensor * llama_graph_result_get_logits(class llm_graph_result * res);
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -495,6 +495,8 @@ extern "C" {
 
     LLAMA_API int32_t llama_vocab_n_tokens(const struct llama_vocab * vocab);
 
+    LLAMA_API int32_t llama_model_n_nextn_layer(const struct llama_model * model);
+
     // Functions to access the model's GGUF metadata scalar values
     // - The functions return the length of the string on success, or -1 on failure
     // - The output string is always null-terminated and cleared on failure

--- a/include/llama.h
+++ b/include/llama.h
@@ -223,10 +223,8 @@ extern "C" {
     //
     typedef enum {
         MTP_OP_NONE,
-        MTP_OP_WARMUP,
-        MTP_OP_UPDATE_ACCEPTED,
-        MTP_OP_DRAFT_GEN,
-        MTP_OP_MAIN_VALIDATION,
+        MTP_OP_DRAFT_ONLY,
+        MTP_OP_UNIFIED,
     } llama_mtp_op_type;
 
     typedef struct llama_mtp_params {
@@ -1472,26 +1470,6 @@ extern "C" {
     //
 
     LLAMA_API void llama_set_draft_input_hidden_state(struct llama_context * ctx, const float * hidden_state);
-
-    /**
-     * @brief Prepares the context for an MTP KV cache update by creating a resized copy of the last sinfo.
-     *        This is used after speculative validation when only a subset of draft tokens are accepted.
-     * @param n_accepted The number of tokens that were accepted and for which the sinfo should be resized.
-     * @return true on success.
-     */
-    LLAMA_API bool llama_mtp_prepare_sinfo_for_update(struct llama_context * ctx, size_t n_accepted);
-    
-    /**
-     * @brief Prepares the context for an MTP KV cache update by reusing the sinfo from the last main model decode.
-     *        This is used for the prompt warmup to ensure the MTP and main model KV caches are perfectly aligned.
-     * @return true on success.
-     */
-    LLAMA_API bool llama_mtp_prepare_sinfo_for_warmup(struct llama_context * ctx);
-    
-    /**
-     * @brief Clears the forced sinfo state from the context. Must be called after a decode that used a prepared sinfo.
-     */
-    LLAMA_API void llama_mtp_cancel_sinfo_update(struct llama_context * ctx);
 
     /**
      * @brief Removes KV cache metadata for a specified sequence and token range.

--- a/include/llama.h
+++ b/include/llama.h
@@ -226,6 +226,7 @@ extern "C" {
         MTP_OP_WARMUP,
         MTP_OP_UPDATE_ACCEPTED,
         MTP_OP_DRAFT_GEN,
+        MTP_OP_MAIN_VALIDATION,
     } llama_mtp_op_type;
 
     typedef struct llama_mtp_params {

--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -2240,12 +2240,13 @@ static const std::map<llm_tensor, llm_tensor_info> LLM_TENSOR_INFOS = {
     {LLM_TENSOR_SHORTCONV_OUTPROJ,          {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
     // NextN/MTP tensors are currently ignored (reserved for future MTP support)
     // These tensors only exist in the last layer(s) and are treated as output tensors
-    {LLM_TENSOR_NEXTN_EH_PROJ,              {LLM_TENSOR_LAYER_OUTPUT, GGML_OP_MUL_MAT}},
-    {LLM_TENSOR_NEXTN_EMBED_TOKENS,         {LLM_TENSOR_LAYER_OUTPUT, GGML_OP_GET_ROWS}},
-    {LLM_TENSOR_NEXTN_ENORM,                {LLM_TENSOR_LAYER_OUTPUT, GGML_OP_GET_ROWS}},
-    {LLM_TENSOR_NEXTN_HNORM,                {LLM_TENSOR_LAYER_OUTPUT, GGML_OP_MUL}},
-    {LLM_TENSOR_NEXTN_SHARED_HEAD_HEAD,     {LLM_TENSOR_LAYER_OUTPUT, GGML_OP_MUL_MAT}},
-    {LLM_TENSOR_NEXTN_SHARED_HEAD_NORM,     {LLM_TENSOR_LAYER_OUTPUT, GGML_OP_MUL}},
+    // Changed to LLM_TENSOR_LAYER_REPEATING because we saved these under a blk with a non-negative id
+    {LLM_TENSOR_NEXTN_EH_PROJ,              {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
+    {LLM_TENSOR_NEXTN_EMBED_TOKENS,         {LLM_TENSOR_LAYER_REPEATING, GGML_OP_GET_ROWS}},
+    {LLM_TENSOR_NEXTN_ENORM,                {LLM_TENSOR_LAYER_REPEATING, GGML_OP_GET_ROWS}},
+    {LLM_TENSOR_NEXTN_HNORM,                {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL}},
+    {LLM_TENSOR_NEXTN_SHARED_HEAD_HEAD,     {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
+    {LLM_TENSOR_NEXTN_SHARED_HEAD_NORM,     {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL}},
 };
 
 LLM_KV::LLM_KV(llm_arch arch, const char * suffix) : arch(arch), suffix(suffix) {}

--- a/src/llama-batch.cpp
+++ b/src/llama-batch.cpp
@@ -275,7 +275,9 @@ bool llama_batch_allocr::init(
                 }
             }
 
-            if (!ok) {
+            // TEMPORARILY DISABLING THIS SANITY CHECK
+            // TODO: UNDO THIS IF IT WORKS
+            /*if (!ok) {
                 LLAMA_LOG_ERROR(
                         "%s: the tokens of sequence %d in the input batch have inconsistent sequence positions:\n"
                         " - the last position stored in the memory module of the context (i.e. the KV cache) for sequence %d is X = %d\n"
@@ -284,7 +286,7 @@ bool llama_batch_allocr::init(
                         __func__, s, s, p0, s, seq_pos_min(s));
 
                 return false;
-            }
+            }*/
         }
 
         if (seq_pos_max(s) - seq_pos_min(s) + 1 > (int) seq_pos[s].size()) {

--- a/src/llama-batch.cpp
+++ b/src/llama-batch.cpp
@@ -841,6 +841,7 @@ struct llama_batch llama_batch_init(int32_t n_tokens_alloc, int32_t embd, int32_
         /*n_seq_id      =*/ nullptr,
         /*seq_id        =*/ nullptr,
         /*logits        =*/ nullptr,
+        /*.use_mtp_head =*/ false,
         /*update_mtp_kv =*/ false,
     };
 

--- a/src/llama-batch.cpp
+++ b/src/llama-batch.cpp
@@ -841,9 +841,7 @@ struct llama_batch llama_batch_init(int32_t n_tokens_alloc, int32_t embd, int32_
         /*n_seq_id      =*/ nullptr,
         /*seq_id        =*/ nullptr,
         /*logits        =*/ nullptr,
-        /*.use_mtp_head =*/ false,
-        /*update_mtp_kv =*/ false,
-        /*.is_mtp_prompt_warmup =*/ false,
+        /*.mtp_params   =*/ { MTP_OP_NONE },
     };
 
     if (embd) {

--- a/src/llama-batch.cpp
+++ b/src/llama-batch.cpp
@@ -843,6 +843,7 @@ struct llama_batch llama_batch_init(int32_t n_tokens_alloc, int32_t embd, int32_
         /*logits        =*/ nullptr,
         /*.use_mtp_head =*/ false,
         /*update_mtp_kv =*/ false,
+        /*.is_mtp_prompt_warmup =*/ false,
     };
 
     if (embd) {

--- a/src/llama-batch.cpp
+++ b/src/llama-batch.cpp
@@ -834,13 +834,14 @@ struct llama_batch llama_batch_get_one(
 
 struct llama_batch llama_batch_init(int32_t n_tokens_alloc, int32_t embd, int32_t n_seq_max) {
     llama_batch batch = {
-        /*n_tokens =*/ 0,
-        /*tokens   =*/ nullptr,
-        /*embd     =*/ nullptr,
-        /*pos      =*/ nullptr,
-        /*n_seq_id =*/ nullptr,
-        /*seq_id   =*/ nullptr,
-        /*logits   =*/ nullptr,
+        /*n_tokens      =*/ 0,
+        /*tokens        =*/ nullptr,
+        /*embd          =*/ nullptr,
+        /*pos           =*/ nullptr,
+        /*n_seq_id      =*/ nullptr,
+        /*seq_id        =*/ nullptr,
+        /*logits        =*/ nullptr,
+        /*update_mtp_kv =*/ false,
     };
 
     if (embd) {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1146,7 +1146,14 @@ int llama_context::decode(const llama_batch & batch_inp) {
             // needs to happen before the graph is built
             n_outputs = n_outputs_new;
         }
-
+        if (do_mtp_kv_update) {
+            LLAMA_LOG_WARN("[DEBUG-MTP-UPDATE] MTP KV Update ubatch: n_tokens=%d\n", ubatch.n_tokens);
+            std::string positions_str;
+            for (int i = 0; i < ubatch.n_tokens; ++i) {
+                positions_str += std::to_string(ubatch.pos[i]) + " ";
+            }
+            LLAMA_LOG_WARN("[DEBUG-MTP-UPDATE] Positions: %s\n", positions_str.c_str());
+        }
         ggml_status status;
         const auto * res = process_ubatch(ubatch, LLM_GRAPH_TYPE_DECODER, mctx.get(), status, do_mtp_kv_update, use_mtp_head);
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2995,7 +2995,7 @@ void llama_opt_epoch(
         callback_eval);
 }
 
-void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
+llama_token llama_build_and_execute_mtp_graph(struct llama_context * ctx,
     const llama_batch batch_inp, llama_token last_token_id, int32_t n_past, int32_t last_tok_idx) {
 
     const auto * model = llama_get_model(ctx);
@@ -3044,13 +3044,29 @@ void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
 
     ggml_backend_sched_graph_compute(sched, gf); // execute the graph
 
-    struct ggml_tensor * logits_mtp = res_mtp->get_logits();;
+    //struct ggml_tensor * logits_mtp = res_mtp->get_logits();
+
     //LLAMA_LOG_INFO("logits_mtp pointer address: %p\n", (void*)logits_mtp);
 
-    if (logits_mtp) {
-        ctx->set_logits_ith(logits_mtp, sched, last_tok_idx);
-    }
+    //if (logits_mtp) {
+    //    ctx->set_logits_ith(logits_mtp, sched, last_tok_idx);
+    //}
+    struct ggml_tensor * token_id_tensor = ggml_get_tensor(res_mtp->get_ctx(), "mtp_argmax_result");
+
+
+    llama_token token_id = 0; // The C++ variable to hold the result.
+
+    // ggml_backend_tensor_get is the function for GPU->CPU copies.
+    // We are copying a single 32-bit integer.
+    ggml_backend_tensor_get(
+        token_id_tensor,
+        &token_id,                // Pointer to our C++ variable
+        0,                        // Starting offset in bytes
+        sizeof(llama_token)       // Number of bytes to copy
+    );
 
     ggml_backend_sched_free(sched);
+
+    return token_id;
 }
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3050,5 +3050,7 @@ void llama_build_and_execute_mtp_graph(struct llama_context * ctx,
     if (logits_mtp) {
         ctx->set_logits_ith(logits_mtp, sched, last_tok_idx);
     }
+
+    ggml_backend_sched_free(sched);
 }
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -126,6 +126,8 @@ llama_context::llama_context(
     cparams.kv_unified = params.kv_unified;
 
     kv_cache_data = new llama_context_kv_cache_data();
+    auto * kvd = static_cast<llama_context_kv_cache_data *>(kv_cache_data);
+    kvd->gf_res_prev_validation = std::make_unique<llm_graph_result>(graph_max_nodes());
 
     {
         const char * LLAMA_SET_ROWS = getenv("LLAMA_SET_ROWS");
@@ -303,9 +305,10 @@ llama_context::llama_context(
         }
 
         sched.reset(ggml_backend_sched_new(backend_ptrs.data(), backend_buft.data(), backend_ptrs.size(), max_nodes, pipeline_parallel, cparams.op_offload));
+        sched_mtp.reset(ggml_backend_sched_new(backend_ptrs.data(), backend_buft.data(), backend_ptrs.size(), max_nodes, pipeline_parallel, cparams.op_offload));
 
         if (pipeline_parallel) {
-            LLAMA_LOG_INFO("%s: pipeline parallelism enabled (n_copies=%d)\n", __func__, ggml_backend_sched_get_n_copies(sched.get()));
+            LLAMA_LOG_INFO("%s: pipeline parallelism enabled (n_copies=%d)\n", __func__, ggml_backend_sched_get_n_copies(sched.get()), ggml_backend_sched_get_n_copies(sched_mtp.get()));
         }
     }
 
@@ -752,8 +755,7 @@ bool llama_context::apply_adapter_cvec(
     return cvec.apply(model, data, len, n_embd, il_start, il_end);
 }
 
-llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, llm_graph_type gtype, llama_memory_context_i * mctx, ggml_status & ret,
-                                                const llama_mtp_params & mtp_params) {
+llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, llm_graph_type gtype, llama_memory_context_i * mctx, ggml_status & ret, const llama_mtp_params & mtp_params) {
     if (mctx && !mctx->apply()) {
         LLAMA_LOG_ERROR("%s: failed to apply memory context\n", __func__);
         ret = GGML_STATUS_FAILED;
@@ -761,116 +763,77 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
     }
 
     auto * kvd = static_cast<llama_context_kv_cache_data *>(kv_cache_data);
-    llm_graph_result * res;
+    
+    ggml_backend_sched * current_sched = nullptr;
+    llm_graph_result * res = nullptr;
 
-    if (mtp_params.op_type != MTP_OP_NONE) {
+    if (mtp_params.op_type == MTP_OP_DRAFT_ONLY) {
+        current_sched = sched_mtp.get();
+
         int32_t n_outputs = 0;
         for (int i = 0; i < ubatch.n_tokens; ++i) { if (ubatch.output[i]) n_outputs++; }
-        const llama_graph_cache_key key = { ubatch.n_tokens, (uint32_t)n_outputs, mtp_params.op_type, cparams.causal_attn };
+        
+        const llama_graph_cache_key key = { 
+            (uint32_t)ubatch.n_tokens, 
+            (uint32_t)n_outputs, 
+            mtp_params.op_type,
+            cparams.causal_attn 
+        };
 
         auto & res_ptr = kvd->graph_cache[key];
         if (!res_ptr) {
-            LLAMA_LOG_INFO("[GRAPH-CACHE] Creating a new graph container for key (op=%d, tok=%d, out=%d)\n",
-                (int)key.op_type, key.n_tokens, key.n_outputs);
+            // LLAMA_LOG_INFO("[CACHE] New Entry: op=%d tokens=%d\n", key.op_type, key.n_tokens);
             res_ptr = std::make_unique<llm_graph_result>(graph_max_nodes());
         }
         res = res_ptr.get();
+        
+    } else {
+        current_sched = sched.get();
+        res = gf_res_prev.get();
+    }
 
-        // the new graph parameters
-        // in order to correctly reuse a graph, it's full topology has to be uniquely determined by these parameters
-        const auto gparams = graph_params(res, ubatch, mctx, gtype, mtp_params);
+    const auto gparams = graph_params(res, ubatch, mctx, gtype, mtp_params);
+
+    bool structure_hit = !graph_reuse_disable && res->can_reuse(gparams);
+
+    if (structure_hit) {
+        LLAMA_LOG_INFO("[GRAPH-REUSE] HIT (op=%d)\n", mtp_params.op_type);
+        if (current_sched == sched.get()) {
+            ggml_backend_sched_reset(current_sched);
+            
+            if (!ggml_backend_sched_alloc_graph(current_sched, res->gf)) {
+                LLAMA_LOG_ERROR("%s: failed to allocate graph on reuse\n", __func__);
+                return nullptr;
+            }
+        }
         
-        // if (!graph_reuse_disable && res->can_reuse(gparams)) {
-        //LLAMA_LOG_DEBUG("%s: reusing previous graph\n", __func__);
-        //     LLAMA_LOG_INFO("[GRAPH-CACHE] HIT, reusing graph STRUCTURE for key (op=%d, tok=%d, out=%d)\n",
-        //         (int)key.op_type, key.n_tokens, key.n_outputs);
-        //     n_reused++;
-        // } else {
-        LLAMA_LOG_INFO("[GRAPH-CACHE] MISS, RECONSTRUCTING THE STRUCTURE of the graph for key (op=%d, tok=%d, out=%d)\n",
-            (int)key.op_type, key.n_tokens, key.n_outputs);
+        res->set_inputs(&ubatch); 
+
+    } else {
+        LLAMA_LOG_INFO("[GRAPH-REUSE] MISS (op=%d) - Rebuilding\n", mtp_params.op_type);  
         
-        const int64_t t_reset_start_us = ggml_time_us();
-        ggml_backend_sched_reset(sched.get());
-        const int64_t t_reset_end_us = ggml_time_us();
-        ggml_backend_sched_set_eval_callback(sched.get(), cparams.cb_eval, cparams.cb_eval_user_data);
+        ggml_backend_sched_reset(current_sched);
+        ggml_backend_sched_set_eval_callback(current_sched, cparams.cb_eval, cparams.cb_eval_user_data);
 
         res->reset();
         res->set_params(gparams);
-        const int64_t t_build_start_us = ggml_time_us();
         res->gf = model.build_graph(gparams);
-        const int64_t t_build_end_us = ggml_time_us();
-        LLAMA_LOG_INFO("[PERF-GRAPH] Graph build (op=%d): %.2f ms\n", (int)mtp_params.op_type, (t_build_end_us - t_build_start_us) / 1000.0);
 
-        if (!res->gf) {
-            LLAMA_LOG_ERROR("%s: failed to initialize graph\n", __func__);
-            ret = GGML_STATUS_FAILED;
-            return nullptr;
-        }
-
-        const int64_t t_alloc_start_us = ggml_time_us();
-        if (!ggml_backend_sched_alloc_graph(sched.get(), res->gf)) {
-            LLAMA_LOG_ERROR("%s: failed to allocate graph\n", __func__);
-            ret = GGML_STATUS_ALLOC_FAILED;
-            return nullptr;
-        }
-        const int64_t t_alloc_end_us = ggml_time_us();
-            LLAMA_LOG_INFO("[PERF-GRAPH] sched_reset: %.2f ms | sched_alloc: %.2f ms (op=%d)\n",
-                (t_reset_end_us - t_reset_start_us) / 1000.0,
-                (t_alloc_end_us - t_alloc_start_us) / 1000.0,
-                (int)mtp_params.op_type);
-        // }
-
-    } else {
-        res = gf_res_prev.get();
-        const auto gparams = graph_params(res, ubatch, mctx, gtype, mtp_params);
-
-        if (!graph_reuse_disable && res->can_reuse(gparams)) {
-            LLAMA_LOG_INFO("%s: reusing previous graph\n", __func__);
-            n_reused++;
-        } else {
-            LLAMA_LOG_INFO("%s: RECONSTRUCTED graph...\n", __func__);
-
-            const int64_t t_reset_start_us = ggml_time_us();
-            ggml_backend_sched_reset(sched.get());
-            const int64_t t_reset_end_us = ggml_time_us();
-            ggml_backend_sched_set_eval_callback(sched.get(), cparams.cb_eval, cparams.cb_eval_user_data);
-
-            res->reset();
-            res->set_params(gparams);
-            //const auto t_start_us = ggml_time_us();
-
-            const int64_t t_build_start_us = ggml_time_us();
-            res->gf = model.build_graph(gparams);
-            const int64_t t_build_end_us = ggml_time_us();
-            LLAMA_LOG_INFO("[PERF-GRAPH] Graph build (op=%d): %.2f ms\n", (int)mtp_params.op_type, (t_build_end_us - t_build_start_us) / 1000.0);
-
-            //LLAMA_LOG_INFO("graph build time: %.3f ms\n", (ggml_time_us() - t_start_us)/1000.0);
-
-            if (!res->gf) {
-                LLAMA_LOG_ERROR("%s: failed to initialize graph\n", __func__);
-                ret = GGML_STATUS_FAILED;
-                return nullptr;
-            }
-
-            const int64_t t_alloc_start_us = ggml_time_us();
-            if (!ggml_backend_sched_alloc_graph(sched.get(), res->gf)) {
-                LLAMA_LOG_ERROR("%s: failed to allocate graph\n", __func__);
-                ret = GGML_STATUS_ALLOC_FAILED;
-                return nullptr;
-            }
-            const int64_t t_alloc_end_us = ggml_time_us();
-            LLAMA_LOG_INFO("[PERF-GRAPH] sched_reset: %.2f ms | sched_alloc: %.2f ms (op=%d)\n",
-                (t_reset_end_us - t_reset_start_us) / 1000.0,
-                (t_alloc_end_us - t_alloc_start_us) / 1000.0,
-                (int)mtp_params.op_type);
+        if (!ggml_backend_sched_alloc_graph(current_sched, res->gf)) {
+             return nullptr;
         }
     }
 
-    if (mtp_params.op_type != MTP_OP_NONE && mtp_params.op_type != MTP_OP_MAIN_VALIDATION) {
+    if (mtp_params.op_type == MTP_OP_DRAFT_ONLY) {
+        LLAMA_LOG_INFO("[MTP-DEBUG] Executing DRAFT_ONLY path.\n");
+
+        const int64_t t_inputs_start_us = ggml_time_us();
         if (!prepare_mtp_graph_inputs(res, ubatch, mtp_params)) {
             ret = GGML_STATUS_FAILED;
             return nullptr;
         }
+        const int64_t t_inputs_end_us = ggml_time_us();
+        LLAMA_LOG_INFO("[PERF-MTP] DRAFT_ONLY input setup: %.2f ms\n", (t_inputs_end_us - t_inputs_start_us) / 1000.0);
     }
 
     // set the input data for the input tensors
@@ -882,7 +845,10 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         //LLAMA_LOG_INFO("graph set inputs time: %.3f ms\n", (ggml_time_us() - t_start_us)/1000.0);
     }
 
-    const auto status = graph_compute(res->get_gf(), ubatch.n_tokens > 1);
+    const int64_t t_compute_start_us = ggml_time_us();
+    auto status = graph_compute(res->get_gf(), ubatch.n_tokens > 1, current_sched);
+    const int64_t t_compute_end_us = ggml_time_us();
+    LLAMA_LOG_INFO("[PERF-MTP] DRAFT_ONLY graph compute: %.2f ms\n", (t_compute_end_us - t_compute_start_us) / 1000.0);
     if (status != GGML_STATUS_SUCCESS) {
         LLAMA_LOG_ERROR("%s: failed to compute graph, compute status: %d\n", __func__, status);
         ret = status;
@@ -890,9 +856,6 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
     }
 
     ret = GGML_STATUS_SUCCESS;
-    if (mtp_params.op_type == MTP_OP_UPDATE_ACCEPTED) {
-        ggml_tensor * sum_tensor = ggml_get_tensor(res->get_ctx(), "mtp_input_sum");
-    }
     return res;
 }
 
@@ -1123,10 +1086,10 @@ int llama_context::decode(const llama_batch & batch_inp) {
     // handle any pending defrags/shifts
     kv_self_update(false);
 
-    std::unique_ptr<llama_memory_context_i> mctx;
+    llama_memory_context_ptr mctx;
 
     while (true) {
-        mctx = this->initialize_decode_context(batch_inp, output_all);
+        mctx = memory->init_batch(*balloc, cparams.n_ubatch, output_all);
 
         if (!mctx) {
             return -2;
@@ -1238,34 +1201,29 @@ int llama_context::decode(const llama_batch & batch_inp) {
             t_embd = res->get_embd_pooled();
         }
 
+        ggml_backend_sched_t active_sched = sched.get();
+        if (batch_inp.mtp_params.op_type == MTP_OP_DRAFT_ONLY) {
+                active_sched = sched_mtp.get();
+            }
         // extract logits
         if (t_logits && n_outputs > 0) {
-            // MTP operations that are purely for updating the KV cache
-            // (MTP_OP_WARMUP and MTP_OP_UPDATE_ACCEPTED) also produce a logit tensor
-            // as a side effect of running the graph. If these logits are copied
-            // back to the main context buffer, they will overwrite the valid logits
-            // produced by the main model's pass, leading to incorrect sampling.
-            // This condition explicitly prevents that copy for cache-only operations.
-            if (batch_inp.mtp_params.op_type != MTP_OP_WARMUP &&
-                batch_inp.mtp_params.op_type != MTP_OP_UPDATE_ACCEPTED) {
-                ggml_backend_t backend_res = ggml_backend_sched_get_tensor_backend(sched.get(), t_logits);
-                GGML_ASSERT(backend_res != nullptr);
-                GGML_ASSERT(logits != nullptr);
+            ggml_backend_t backend_res = ggml_backend_sched_get_tensor_backend(active_sched, t_logits);
+            GGML_ASSERT(backend_res != nullptr);
+            GGML_ASSERT(logits != nullptr);
 
-                float * logits_out = logits + n_outputs_prev*n_vocab;
+            float * logits_out = logits + n_outputs_prev*n_vocab;
 
-                if (n_outputs) {
-                    GGML_ASSERT( n_outputs_prev + n_outputs <= n_outputs_all);
-                    GGML_ASSERT((n_outputs_prev + n_outputs)*n_vocab <= (int64_t) logits_size);
-                    ggml_backend_tensor_get_async(backend_res, t_logits, logits_out, 0, n_outputs*n_vocab*sizeof(float));
-                }
+            if (n_outputs) {
+                GGML_ASSERT( n_outputs_prev + n_outputs <= n_outputs_all);
+                GGML_ASSERT((n_outputs_prev + n_outputs)*n_vocab <= (int64_t) logits_size);
+                ggml_backend_tensor_get_async(backend_res, t_logits, logits_out, 0, n_outputs*n_vocab*sizeof(float));
             }
         }
 
         // extract embeddings
         if (t_embd && n_outputs > 0) {
-            if (batch_inp.mtp_params.op_type == MTP_OP_NONE || batch_inp.mtp_params.op_type == MTP_OP_MAIN_VALIDATION) {
-                ggml_backend_t backend_embd = ggml_backend_sched_get_tensor_backend(sched.get(), t_embd);
+            if (batch_inp.mtp_params.op_type == MTP_OP_NONE || batch_inp.mtp_params.op_type == MTP_OP_UNIFIED) {
+                ggml_backend_t backend_embd = ggml_backend_sched_get_tensor_backend(active_sched, t_embd);
                 GGML_ASSERT(backend_embd != nullptr);
 
                 switch (cparams.pooling_type) {
@@ -1503,6 +1461,9 @@ ggml_cgraph * llama_context::graph_reserve(uint32_t n_tokens, uint32_t n_seqs, u
     }
 
     ggml_backend_sched_reset(sched.get());
+    if (sched_mtp) {
+        ggml_backend_sched_reset(sched_mtp.get());
+    }
 
     // when the scheduler is reset, we cannnot reuse the old graph, so we reset the previous graph result to prevent that
     gf_res_prev->reset();
@@ -1575,9 +1536,7 @@ std::unique_ptr<llama_memory_context_i> llama_context::mtp_memory_batch(const ll
     return memory->init_batch(*balloc, 1, false);
 }
 
-ggml_status llama_context::graph_compute(
-            ggml_cgraph * gf,
-                   bool   batched) {
+ggml_status llama_context::graph_compute(ggml_cgraph * gf, bool batched, ggml_backend_sched_t custom_sched) {
     int n_threads        = batched ? cparams.n_threads_batch : cparams.n_threads;
     ggml_threadpool_t tp = batched ? threadpool_batch        : threadpool;
 
@@ -1592,7 +1551,9 @@ ggml_status llama_context::graph_compute(
         set_n_threads_fn.second(set_n_threads_fn.first, n_threads);
     }
 
-    auto status = ggml_backend_sched_graph_compute_async(sched.get(), gf);
+    ggml_backend_sched_t target = custom_sched ? custom_sched : sched.get();
+    
+    auto status = ggml_backend_sched_graph_compute_async(target, gf);
     if (status != GGML_STATUS_SUCCESS) {
         LLAMA_LOG_ERROR("%s: ggml_backend_sched_graph_compute_async failed with error %d\n", __func__, status);
     }
@@ -3087,43 +3048,6 @@ void llama_set_draft_input_hidden_state(struct llama_context * ctx, const float 
     ctx->draft_input_hidden_state = hidden_state;
 }
 
-bool llama_mtp_prepare_sinfo_for_warmup(struct llama_context * ctx) {
-    auto * kvd = static_cast<llama_context_kv_cache_data *>(ctx->kv_cache_data);
-    const auto & last_sinfo = kvd->last_main_model_sinfos;
-
-    if (last_sinfo.empty()) {
-        LLAMA_LOG_ERROR("%s: The main call sinfo is not available for warmup.\n", __func__);
-        return false;
-    }
-
-    kvd->forced_sinfos = &last_sinfo;
-    return true;
-}
-
-
-bool llama_mtp_prepare_sinfo_for_update(struct llama_context * ctx, size_t n_accepted) {
-    auto * kvd = static_cast<llama_context_kv_cache_data *>(ctx->kv_cache_data);
-    const auto & last_sinfo = kvd->last_main_model_sinfos;
-
-    if (last_sinfo.empty() || last_sinfo[0].idxs.empty()) {
-        LLAMA_LOG_ERROR("%s: The sinfo for the last main call is not available.", __func__);
-        return false;
-    }
-
-    kvd->resized_sinfo_for_force = last_sinfo;
-    
-    kvd->resized_sinfo_for_force[0].idxs[0].resize(n_accepted);
-
-    kvd->forced_sinfos = &kvd->resized_sinfo_for_force;
-
-    return true;
-}
-
-void llama_mtp_cancel_sinfo_update(struct llama_context * ctx) {
-    auto * kvd = static_cast<llama_context_kv_cache_data *>(ctx->kv_cache_data);
-    kvd->forced_sinfos = nullptr;
-}
-
 void llama_context::kv_cache_seq_rm(llama_seq_id seq_id, llama_pos p0, llama_pos p1) {
     if (memory) {
         static_cast<llama_kv_cache_unified *>(memory.get())->seq_rm(seq_id, p0, p1);
@@ -3134,70 +3058,29 @@ void llama_kv_cache_seq_rm(struct llama_context * ctx, llama_seq_id seq_id, llam
     ctx->kv_cache_seq_rm(seq_id, p0, p1);
 }
 
-/*
-    Initializes the memory context for a decode operation.
-    The logic follows a specific priority:
-    1. Warmup: Always use a standard batch initialization.
-    2. Forced S-Info (MTP Updates): If a specific KV cache layout is forced, use it.
-    3. Default: Use a standard batch initialization, and if it's a main model pass,
-       save the resulting s-info for potential future reuse by MTP.
-*/
-std::unique_ptr<llama_memory_context_i> llama_context::initialize_decode_context(const llama_batch & batch_inp, const bool output_all) {
-    auto * kvd = static_cast<llama_context_kv_cache_data *>(kv_cache_data);
-    std::unique_ptr<llama_memory_context_i> mctx;
-
-    if (cparams.warmup) {
-        mctx = memory->init_batch(*balloc, cparams.n_ubatch, output_all);
-    } else if (kvd->forced_sinfos && !kvd->forced_sinfos->empty()) {
-        LLAMA_LOG_DEBUG("%s: Forcing sinfos, bypassing find_slot.\n", __func__);
-        mctx = static_cast<llama_kv_cache_unified *>(memory.get())->init_batch_with_sinfos(
-            *balloc, cparams.n_ubatch, *kvd->forced_sinfos, true
-        );
-    } else {
-        mctx = memory->init_batch(*balloc, cparams.n_ubatch, output_all);
-
-        if (batch_inp.mtp_params.op_type == MTP_OP_NONE || batch_inp.mtp_params.op_type == MTP_OP_MAIN_VALIDATION) {
-            if (mctx && mctx->get_status() == LLAMA_MEMORY_STATUS_SUCCESS) {
-                kvd->last_main_model_sinfos = static_cast<llama_kv_cache_unified_context *>(mctx.get())->get_sinfos();
-            } else {
-                kvd->last_main_model_sinfos.clear();
-            }
-        }
-    }
-    
-    return mctx;
-}
-
-
 bool llama_context::prepare_mtp_graph_inputs(
     llm_graph_result * res,
     const llama_ubatch & ubatch,
     const llama_mtp_params & mtp_params) {
     
-    const char * target_tensor_name = "result_embd_pooled";
-    ggml_tensor* hidden_states_input = ggml_get_tensor(res->get_ctx(), target_tensor_name);
-
-    const float * source_hidden_state = nullptr;
-    if (mtp_params.op_type == MTP_OP_WARMUP || mtp_params.op_type == MTP_OP_UPDATE_ACCEPTED) {
-        source_hidden_state = this->embd;
-    } else { // MTP_OP_DRAFT_GEN
-        source_hidden_state = this->draft_input_hidden_state;
+    // We only need to inject hidden states manually for the DRAFT_ONLY path.
+    if (mtp_params.op_type != MTP_OP_DRAFT_ONLY) {
+        return true;
     }
 
-    if (source_hidden_state != nullptr && hidden_states_input != nullptr) {
-        const char * op_type;
-        if (mtp_params.op_type == MTP_OP_WARMUP || mtp_params.op_type == MTP_OP_UPDATE_ACCEPTED) {
-            op_type = "MTP_UPDATE";
-        } else { // MTP_OP_DRAFT_GEN
-            op_type = "DRAFT_GEN";
-        }
-
-        ggml_backend_tensor_set(hidden_states_input, source_hidden_state, 0, ggml_nbytes(hidden_states_input));
-    } else {
-        LLAMA_LOG_ERROR("%s: MTP hidden state input tensor ('%s') not found or main embd buffer is null\n",
-            __func__, target_tensor_name);
+    struct ggml_tensor * inp_mtp = ggml_graph_get_tensor(res->gf, "mtp_draft_hidden_state");
+    if (!inp_mtp) {
+        LLAMA_LOG_ERROR("MTP input tensor not found in graph\n");
         return false;
     }
+
+    const float * src_data = this->draft_input_hidden_state;
+    if (!src_data) {
+        LLAMA_LOG_ERROR("%s: Source hidden state data is NULL (draft_input_hidden_state)\n", __func__);
+        return false;
+    }
+
+    ggml_backend_tensor_set(inp_mtp, src_data, 0, ggml_nbytes(inp_mtp));
 
     return true;
 }

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -17,10 +17,24 @@
 //
 // llama_context
 //
+// Key for the graph cache. It contains all parameters that define the graph topology.
+struct llama_graph_cache_key {
+    uint32_t n_tokens;
+    uint32_t n_outputs;
+    llama_mtp_op_type op_type;
+    bool causal_attn;
+
+    bool operator<(const llama_graph_cache_key& other) const {
+        return std::tie(n_tokens, n_outputs, op_type, causal_attn) <
+               std::tie(other.n_tokens, other.n_outputs, other.op_type, other.causal_attn);
+    }
+};
+
 struct llama_context_kv_cache_data {
     llama_kv_cache_unified::slot_info_vec_t last_main_model_sinfos;
     llama_kv_cache_unified::slot_info_vec_t resized_sinfo_for_force;
     const llama_kv_cache_unified::slot_info_vec_t * forced_sinfos = nullptr;
+    std::map<llama_graph_cache_key, llm_graph_result_ptr> graph_cache;
 };
 
 llama_context::llama_context(
@@ -745,39 +759,87 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         return nullptr;
     }
 
-    auto * res = gf_res_prev.get();
-    auto * gf  = res->get_gf();
+    auto * kvd = static_cast<llama_context_kv_cache_data *>(kv_cache_data);
+    llm_graph_result * res;
 
-    // the new graph parameters
-    // in order to correctly reuse a graph, it's full topology has to be uniquely determined by these parameters
-    const auto gparams = graph_params(res, ubatch, mctx, gtype, mtp_params);
+    if (mtp_params.op_type != MTP_OP_NONE) {
+        int32_t n_outputs = 0;
+        for (int i = 0; i < ubatch.n_tokens; ++i) { if (ubatch.output[i]) n_outputs++; }
+        const llama_graph_cache_key key = { ubatch.n_tokens, (uint32_t)n_outputs, mtp_params.op_type, cparams.causal_attn };
 
-    if (!graph_reuse_disable && res->can_reuse(gparams)) {
+        auto & res_ptr = kvd->graph_cache[key];
+        if (!res_ptr) {
+            LLAMA_LOG_INFO("[GRAPH-CACHE] Creating a new graph container for key (op=%d, tok=%d, out=%d)\n",
+                (int)key.op_type, key.n_tokens, key.n_outputs);
+            res_ptr = std::make_unique<llm_graph_result>(graph_max_nodes());
+        }
+        res = res_ptr.get();
+
+        // the new graph parameters
+        // in order to correctly reuse a graph, it's full topology has to be uniquely determined by these parameters
+        const auto gparams = graph_params(res, ubatch, mctx, gtype, mtp_params);
+        
+        // if (!graph_reuse_disable && res->can_reuse(gparams)) {
         //LLAMA_LOG_DEBUG("%s: reusing previous graph\n", __func__);
-
-        n_reused++;
-    } else {
-        res->reset();
-
+        //     LLAMA_LOG_INFO("[GRAPH-CACHE] HIT, reusing graph STRUCTURE for key (op=%d, tok=%d, out=%d)\n",
+        //         (int)key.op_type, key.n_tokens, key.n_outputs);
+        //     n_reused++;
+        // } else {
+        LLAMA_LOG_INFO("[GRAPH-CACHE] MISS, RECONSTRUCTING THE STRUCTURE of the graph for key (op=%d, tok=%d, out=%d)\n",
+            (int)key.op_type, key.n_tokens, key.n_outputs);
+        
         ggml_backend_sched_reset(sched.get());
         ggml_backend_sched_set_eval_callback(sched.get(), cparams.cb_eval, cparams.cb_eval_user_data);
 
-        //const auto t_start_us = ggml_time_us();
+        res->reset();
+        res->set_params(gparams);
+        res->gf = model.build_graph(gparams);
 
-        gf = model.build_graph(gparams);
-
-        //LLAMA_LOG_INFO("graph build time: %.3f ms\n", (ggml_time_us() - t_start_us)/1000.0);
-
-        if (!gf) {
+        if (!res->gf) {
             LLAMA_LOG_ERROR("%s: failed to initialize graph\n", __func__);
             ret = GGML_STATUS_FAILED;
             return nullptr;
         }
 
-        if (!ggml_backend_sched_alloc_graph(sched.get(), gf)) {
+        if (!ggml_backend_sched_alloc_graph(sched.get(), res->gf)) {
             LLAMA_LOG_ERROR("%s: failed to allocate graph\n", __func__);
             ret = GGML_STATUS_ALLOC_FAILED;
             return nullptr;
+        }
+        // }
+
+    } else {
+        res = gf_res_prev.get();
+        const auto gparams = graph_params(res, ubatch, mctx, gtype, mtp_params);
+
+        if (!graph_reuse_disable && res->can_reuse(gparams)) {
+            LLAMA_LOG_INFO("%s: reusing previous graph\n", __func__);
+            n_reused++;
+        } else {
+            LLAMA_LOG_INFO("%s: RECONSTRUCTED graph...\n", __func__);
+
+            ggml_backend_sched_reset(sched.get());
+            ggml_backend_sched_set_eval_callback(sched.get(), cparams.cb_eval, cparams.cb_eval_user_data);
+
+            res->reset();
+            res->set_params(gparams);
+            //const auto t_start_us = ggml_time_us();
+
+            res->gf = model.build_graph(gparams);
+
+            //LLAMA_LOG_INFO("graph build time: %.3f ms\n", (ggml_time_us() - t_start_us)/1000.0);
+
+            if (!res->gf) {
+                LLAMA_LOG_ERROR("%s: failed to initialize graph\n", __func__);
+                ret = GGML_STATUS_FAILED;
+                return nullptr;
+            }
+
+            if (!ggml_backend_sched_alloc_graph(sched.get(), res->gf)) {
+                LLAMA_LOG_ERROR("%s: failed to allocate graph\n", __func__);
+                ret = GGML_STATUS_ALLOC_FAILED;
+                return nullptr;
+            }
         }
     }
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -35,6 +35,7 @@ struct llama_context_kv_cache_data {
     llama_kv_cache_unified::slot_info_vec_t resized_sinfo_for_force;
     const llama_kv_cache_unified::slot_info_vec_t * forced_sinfos = nullptr;
     std::map<llama_graph_cache_key, llm_graph_result_ptr> graph_cache;
+    llm_graph_result_ptr gf_res_prev_validation; 
 };
 
 llama_context::llama_context(
@@ -788,12 +789,17 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         LLAMA_LOG_INFO("[GRAPH-CACHE] MISS, RECONSTRUCTING THE STRUCTURE of the graph for key (op=%d, tok=%d, out=%d)\n",
             (int)key.op_type, key.n_tokens, key.n_outputs);
         
+        const int64_t t_reset_start_us = ggml_time_us();
         ggml_backend_sched_reset(sched.get());
+        const int64_t t_reset_end_us = ggml_time_us();
         ggml_backend_sched_set_eval_callback(sched.get(), cparams.cb_eval, cparams.cb_eval_user_data);
 
         res->reset();
         res->set_params(gparams);
+        const int64_t t_build_start_us = ggml_time_us();
         res->gf = model.build_graph(gparams);
+        const int64_t t_build_end_us = ggml_time_us();
+        LLAMA_LOG_INFO("[PERF-GRAPH] Graph build (op=%d): %.2f ms\n", (int)mtp_params.op_type, (t_build_end_us - t_build_start_us) / 1000.0);
 
         if (!res->gf) {
             LLAMA_LOG_ERROR("%s: failed to initialize graph\n", __func__);
@@ -801,11 +807,17 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
             return nullptr;
         }
 
+        const int64_t t_alloc_start_us = ggml_time_us();
         if (!ggml_backend_sched_alloc_graph(sched.get(), res->gf)) {
             LLAMA_LOG_ERROR("%s: failed to allocate graph\n", __func__);
             ret = GGML_STATUS_ALLOC_FAILED;
             return nullptr;
         }
+        const int64_t t_alloc_end_us = ggml_time_us();
+            LLAMA_LOG_INFO("[PERF-GRAPH] sched_reset: %.2f ms | sched_alloc: %.2f ms (op=%d)\n",
+                (t_reset_end_us - t_reset_start_us) / 1000.0,
+                (t_alloc_end_us - t_alloc_start_us) / 1000.0,
+                (int)mtp_params.op_type);
         // }
 
     } else {
@@ -818,14 +830,19 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         } else {
             LLAMA_LOG_INFO("%s: RECONSTRUCTED graph...\n", __func__);
 
+            const int64_t t_reset_start_us = ggml_time_us();
             ggml_backend_sched_reset(sched.get());
+            const int64_t t_reset_end_us = ggml_time_us();
             ggml_backend_sched_set_eval_callback(sched.get(), cparams.cb_eval, cparams.cb_eval_user_data);
 
             res->reset();
             res->set_params(gparams);
             //const auto t_start_us = ggml_time_us();
 
+            const int64_t t_build_start_us = ggml_time_us();
             res->gf = model.build_graph(gparams);
+            const int64_t t_build_end_us = ggml_time_us();
+            LLAMA_LOG_INFO("[PERF-GRAPH] Graph build (op=%d): %.2f ms\n", (int)mtp_params.op_type, (t_build_end_us - t_build_start_us) / 1000.0);
 
             //LLAMA_LOG_INFO("graph build time: %.3f ms\n", (ggml_time_us() - t_start_us)/1000.0);
 
@@ -835,15 +852,21 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
                 return nullptr;
             }
 
+            const int64_t t_alloc_start_us = ggml_time_us();
             if (!ggml_backend_sched_alloc_graph(sched.get(), res->gf)) {
                 LLAMA_LOG_ERROR("%s: failed to allocate graph\n", __func__);
                 ret = GGML_STATUS_ALLOC_FAILED;
                 return nullptr;
             }
+            const int64_t t_alloc_end_us = ggml_time_us();
+            LLAMA_LOG_INFO("[PERF-GRAPH] sched_reset: %.2f ms | sched_alloc: %.2f ms (op=%d)\n",
+                (t_reset_end_us - t_reset_start_us) / 1000.0,
+                (t_alloc_end_us - t_alloc_start_us) / 1000.0,
+                (int)mtp_params.op_type);
         }
     }
 
-    if (mtp_params.op_type != MTP_OP_NONE) { // If it is any MTP operation
+    if (mtp_params.op_type != MTP_OP_NONE && mtp_params.op_type != MTP_OP_MAIN_VALIDATION) {
         if (!prepare_mtp_graph_inputs(res, ubatch, mtp_params)) {
             ret = GGML_STATUS_FAILED;
             return nullptr;
@@ -1241,7 +1264,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
         // extract embeddings
         if (t_embd && n_outputs > 0) {
-            if (batch_inp.mtp_params.op_type == MTP_OP_NONE) {
+            if (batch_inp.mtp_params.op_type == MTP_OP_NONE || batch_inp.mtp_params.op_type == MTP_OP_MAIN_VALIDATION) {
                 ggml_backend_t backend_embd = ggml_backend_sched_get_tensor_backend(sched.get(), t_embd);
                 GGML_ASSERT(backend_embd != nullptr);
 
@@ -3133,7 +3156,7 @@ std::unique_ptr<llama_memory_context_i> llama_context::initialize_decode_context
     } else {
         mctx = memory->init_batch(*balloc, cparams.n_ubatch, output_all);
 
-        if (batch_inp.mtp_params.op_type == MTP_OP_NONE) {
+        if (batch_inp.mtp_params.op_type == MTP_OP_NONE || batch_inp.mtp_params.op_type == MTP_OP_MAIN_VALIDATION) {
             if (mctx && mctx->get_status() == LLAMA_MEMORY_STATUS_SUCCESS) {
                 kvd->last_main_model_sinfos = static_cast<llama_kv_cache_unified_context *>(mctx.get())->get_sinfos();
             } else {

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -99,7 +99,8 @@ struct llama_context {
                 const llama_ubatch & ubatch,
                     llm_graph_type   gtype,
             llama_memory_context_i * mctx,
-                       ggml_status & ret);
+                       ggml_status & ret,
+                const bool do_mtp_kv_update);
 
     int encode(const llama_batch & batch_inp);
     int decode(const llama_batch & batch_inp);
@@ -200,8 +201,6 @@ public:
     // reserve a graph with a dummy ubatch of the specified size
     ggml_cgraph * graph_reserve(uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_context_i * mctx);
 
-    llm_graph_params mtp_graph_params(llm_graph_result * res, const llama_ubatch & ubatch, const llama_memory_context_i * mctx);
-
     void set_logits_ith(struct ggml_tensor * logit_override, ggml_backend_sched_t sched_override, int32_t i);
 
     ggml_backend_sched_t create_temp_scheduler(size_t n_nodes);
@@ -213,7 +212,8 @@ private:
                         llm_graph_result * res,
                       const llama_ubatch & ubatch,
             const llama_memory_context_i * mctx,
-                          llm_graph_type   gtype) const;
+                          llm_graph_type   gtype,
+                           bool update_mtp_kv) const;
 
     llm_graph_cb graph_get_cb(ggml_backend_sched * sched_override = nullptr) const;
 

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -30,6 +30,10 @@ struct llama_context {
 
     ~llama_context();
     
+    // The llama_context manages significant resources (GPU memory, file handles, PImpl data)
+    // and is fundamentally a non-copyable, non-movable object. Deleting these special
+    // member functions enforces this rule and is also technically required to allow the
+    // PImpl pattern (via unique_ptr or void*) with an incomplete type in the header.
     llama_context(const llama_context &) = delete;
     llama_context & operator=(const llama_context &) = delete;
     llama_context(llama_context &&) = delete;

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -103,7 +103,8 @@ struct llama_context {
             llama_memory_context_i * mctx,
                        ggml_status & ret,
                 const bool do_mtp_kv_update,
-                const bool use_mtp_head);
+                const bool use_mtp_head,
+                bool is_mtp_prompt_warmup);
 
     int encode(const llama_batch & batch_inp);
     int decode(const llama_batch & batch_inp);

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -111,9 +111,7 @@ struct llama_context {
                     llm_graph_type   gtype,
             llama_memory_context_i * mctx,
                        ggml_status & ret,
-                const bool do_mtp_kv_update,
-                const bool use_mtp_head,
-                bool is_mtp_prompt_warmup);
+                const llama_mtp_params & mtp_params);
 
     int encode(const llama_batch & batch_inp);
     int decode(const llama_batch & batch_inp);
@@ -229,8 +227,7 @@ private:
                       const llama_ubatch & ubatch,
             const llama_memory_context_i * mctx,
                           llm_graph_type   gtype,
-                           bool update_mtp_kv,
-                           bool use_mtp_head) const;
+                           const llama_mtp_params & mtp_params) const;
 
     llm_graph_cb graph_get_cb(ggml_backend_sched * sched_override = nullptr) const;
 

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -231,6 +231,14 @@ private:
 
     llm_graph_cb graph_get_cb(ggml_backend_sched * sched_override = nullptr) const;
 
+    // Methods for MTP decode     
+    std::unique_ptr<llama_memory_context_i> initialize_decode_context(const llama_batch & batch_inp, const bool output_all);
+
+    bool prepare_mtp_graph_inputs(
+        llm_graph_result * res,
+        const llama_ubatch & ubatch,
+        const llama_mtp_params & mtp_params);
+
     // TODO: read/write lora adapters and cvec
     size_t state_write_data(llama_io_write_i & io);
     size_t state_read_data (llama_io_read_i  & io);

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -20,6 +20,8 @@ class llama_io_write_i;
 struct llama_memory_i;
 struct llama_memory_context_i;
 
+struct llama_context_kv_cache_data;
+
 struct llama_context {
     // init scheduler and compute buffers, reserve worst-case graphs
     llama_context(
@@ -27,6 +29,11 @@ struct llama_context {
                   llama_context_params params);
 
     ~llama_context();
+    
+    llama_context(const llama_context &) = delete;
+    llama_context & operator=(const llama_context &) = delete;
+    llama_context(llama_context &&) = delete;
+    llama_context & operator=(llama_context &&) = delete;
 
     void synchronize();
 
@@ -210,6 +217,9 @@ public:
     ggml_backend_sched_t create_temp_scheduler(size_t n_nodes);
 
     std::unique_ptr<llama_memory_context_i> mtp_memory_batch(const llama_batch& batch_inp);
+
+    // For MTP KV cache cell reuse
+    void * kv_cache_data;
 
 private:
     llm_graph_params graph_params(

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -61,6 +61,8 @@ struct llama_context {
     float * get_embeddings_seq(llama_seq_id seq_id);
     ggml_tensor * get_embeddings_tensor();
 
+    const float * draft_input_hidden_state = nullptr;
+
     void attach_threadpool(
             ggml_threadpool_t threadpool,
             ggml_threadpool_t threadpool_batch);
@@ -100,7 +102,8 @@ struct llama_context {
                     llm_graph_type   gtype,
             llama_memory_context_i * mctx,
                        ggml_status & ret,
-                const bool do_mtp_kv_update);
+                const bool do_mtp_kv_update,
+                const bool use_mtp_head);
 
     int encode(const llama_batch & batch_inp);
     int decode(const llama_batch & batch_inp);
@@ -213,7 +216,8 @@ private:
                       const llama_ubatch & ubatch,
             const llama_memory_context_i * mctx,
                           llm_graph_type   gtype,
-                           bool update_mtp_kv) const;
+                           bool update_mtp_kv,
+                           bool use_mtp_head) const;
 
     llm_graph_cb graph_get_cb(ggml_backend_sched * sched_override = nullptr) const;
 

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -100,6 +100,8 @@ struct llama_context {
                 int32_t   il_start,
                 int32_t   il_end);
 
+    void kv_cache_seq_rm(llama_seq_id seq_id, llama_pos p0, llama_pos p1);
+
     // process a single ubatch with a specific graph type
     // if memory_context is provided, it will be applied first to the context's memory
     // ret contains the status of the graph computation

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -59,6 +59,7 @@ struct llama_context {
     float * get_embeddings();
     float * get_embeddings_ith(int32_t i);
     float * get_embeddings_seq(llama_seq_id seq_id);
+    ggml_tensor * get_embeddings_tensor();
 
     void attach_threadpool(
             ggml_threadpool_t threadpool,
@@ -199,6 +200,10 @@ public:
     // reserve a graph with a dummy ubatch of the specified size
     ggml_cgraph * graph_reserve(uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_context_i * mctx);
 
+    llm_graph_params mtp_graph_params(llm_graph_result * res, const llama_ubatch & ubatch) const;
+
+    void set_logits(struct ggml_tensor* logit_override);
+
 private:
     llm_graph_params graph_params(
                         llm_graph_result * res,
@@ -240,6 +245,7 @@ private:
     // populated only when pooling_type == LLAMA_POOLING_TYPE_NONE
     size_t  embd_size = 0; // capacity (of floats) for embeddings
     float * embd      = nullptr;
+    ggml_tensor * embd_tensor = nullptr;
 
     // sequence embeddings output (map of [n_embd] vectors)
     // populated only when pooling_type != LLAMA_POOLING_TYPE_NONE
@@ -308,3 +314,4 @@ private:
 
     mutable int32_t n_reused = 0; // number of times the previous graph was reused
 };
+

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -200,11 +200,13 @@ public:
     // reserve a graph with a dummy ubatch of the specified size
     ggml_cgraph * graph_reserve(uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_context_i * mctx);
 
-    llm_graph_params mtp_graph_params(llm_graph_result * res, const llama_ubatch & ubatch);
+    llm_graph_params mtp_graph_params(llm_graph_result * res, const llama_ubatch & ubatch, const llama_memory_context_i * mctx);
 
     void set_logits_ith(struct ggml_tensor * logit_override, ggml_backend_sched_t sched_override, int32_t i);
 
     ggml_backend_sched_t create_temp_scheduler(size_t n_nodes);
+
+    std::unique_ptr<llama_memory_context_i> mtp_memory_batch(const llama_batch& batch_inp);
 
 private:
     llm_graph_params graph_params(

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -200,9 +200,11 @@ public:
     // reserve a graph with a dummy ubatch of the specified size
     ggml_cgraph * graph_reserve(uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_context_i * mctx);
 
-    llm_graph_params mtp_graph_params(llm_graph_result * res, const llama_ubatch & ubatch) const;
+    llm_graph_params mtp_graph_params(llm_graph_result * res, const llama_ubatch & ubatch);
 
-    void set_logits(struct ggml_tensor* logit_override);
+    void set_logits_ith(struct ggml_tensor * logit_override, ggml_backend_sched_t sched_override, int32_t i);
+
+    ggml_backend_sched_t create_temp_scheduler(size_t n_nodes);
 
 private:
     llm_graph_params graph_params(
@@ -211,7 +213,7 @@ private:
             const llama_memory_context_i * mctx,
                           llm_graph_type   gtype) const;
 
-    llm_graph_cb graph_get_cb() const;
+    llm_graph_cb graph_get_cb(ggml_backend_sched * sched_override = nullptr) const;
 
     // TODO: read/write lora adapters and cvec
     size_t state_write_data(llama_io_write_i & io);

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -211,7 +211,7 @@ public:
     llm_graph_result * get_gf_res_reserve() const;
 
     // returns the result of ggml_backend_sched_graph_compute_async execution
-    ggml_status graph_compute(ggml_cgraph * gf, bool batched);
+    ggml_status graph_compute(ggml_cgraph * gf, bool batched, ggml_backend_sched_t custom_sched = nullptr);
 
     // reserve a graph with a dummy ubatch of the specified size
     ggml_cgraph * graph_reserve(uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_context_i * mctx);
@@ -235,9 +235,7 @@ private:
 
     llm_graph_cb graph_get_cb(ggml_backend_sched * sched_override = nullptr) const;
 
-    // Methods for MTP decode     
-    std::unique_ptr<llama_memory_context_i> initialize_decode_context(const llama_batch & batch_inp, const bool output_all);
-
+    // Methods for MTP decode
     bool prepare_mtp_graph_inputs(
         llm_graph_result * res,
         const llama_ubatch & ubatch,
@@ -296,6 +294,8 @@ private:
     std::vector<swap_info> output_swaps;
 
     ggml_backend_sched_ptr sched;
+
+    ggml_backend_sched_ptr sched_mtp;
 
     ggml_backend_t backend_cpu = nullptr;
     std::vector<ggml_backend_ptr> backends;

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1074,6 +1074,26 @@ ggml_tensor * llm_graph_context::build_inp_embd(ggml_tensor * tok_embd) const {
     return cur;
 }
 
+
+ggml_tensor * llm_graph_context::build_inp_embd_mtp(ggml_tensor * mtp_tok_embd) const {
+    auto inp = std::make_unique<llm_graph_input_embd>();
+    ggml_tensor * cur = nullptr;
+
+    if (ubatch.token) {
+        inp->tokens = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, ubatch.n_tokens);
+        ggml_set_name(inp->tokens, "mtp_inp_tokens");
+        ggml_set_input(inp->tokens);
+
+        cur = ggml_get_rows(ctx0, mtp_tok_embd, inp->tokens);
+    } else {
+        GGML_ABORT("fatal error: MTP update expects token IDs, not embeddings");
+    }
+
+    cb(cur, "mtp_inp_embd", -1);
+    res->add_input(std::move(inp));
+    return cur;
+}
+
 ggml_tensor * llm_graph_context::build_inp_pos() const {
     auto inp = std::make_unique<llm_graph_input_pos>(hparams.n_pos_per_embd());
 

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1911,7 +1911,3 @@ int32_t llama_relative_position_bucket(llama_pos x, llama_pos y, uint64_t n_buck
 
     return relative_bucket;
 }
-
-ggml_tensor * llama_graph_result_get_logits(llm_graph_result * res) {
-    return res->get_logits();
-}

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1911,3 +1911,7 @@ int32_t llama_relative_position_bucket(llama_pos x, llama_pos y, uint64_t n_buck
 
     return relative_bucket;
 }
+
+ggml_tensor * llama_graph_result_get_logits(llm_graph_result * res) {
+    return res->get_logits();
+}

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -442,34 +442,22 @@ void llm_graph_result::set_inputs(const llama_ubatch * ubatch) {
 
 bool llm_graph_result::can_reuse(const llm_graph_params & params) {
     if (!this->params.allow_reuse(params)) {
-        if (debug > 1) {
-            LLAMA_LOG_DEBUG("%s: cannot reuse graph due to incompatible graph parameters\n", __func__);
-        }
-
+        LLAMA_LOG_WARN("[GRAPH-REUSE-FAIL] Failure in 'allow_reuse'. Incompatible parameters.");
+        LLAMA_LOG_WARN("                   n_tokens: %d vs %d, op_type: %d vs %d",
+                       this->params.ubatch.n_tokens, params.ubatch.n_tokens,
+                       (int)this->params.mtp_params.op_type, (int)params.mtp_params.op_type);
         return false;
     }
 
-    if (debug > 1) {
-        LLAMA_LOG_DEBUG("%s: checking compatibility of %d inputs:\n", __func__, (int) inputs.size());
-    }
-
-    bool res = true;
-
-    for (auto & input : inputs) {
-        const bool cur = input->can_reuse(params);
-
-        if (debug > 1) {
-            LLAMA_LOG_DEBUG("%s: can_reuse = %d\n", "placeholder", cur);
+    for (size_t i = 0; i < inputs.size(); ++i) {
+        if (!inputs[i]->can_reuse(params)) {
+            LLAMA_LOG_WARN("[GRAPH-REUSE-FAIL] Failure in 'can_reuse' of the input node #%zu.", i);
+            return false;
         }
-
-        res = res && cur;
     }
 
-    if (debug > 0) {
-        LLAMA_LOG_DEBUG("%s: can reuse graph = %d\n", __func__, res);
-    }
-
-    return res;
+    LLAMA_LOG_DEBUG("%s: can reuse graph = true\n", __func__);
+    return true;
 }
 
 llm_graph_input_i * llm_graph_result::add_input(llm_graph_input_ptr input) {

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -664,6 +664,7 @@ struct llm_graph_context {
     //
 
     ggml_tensor * build_inp_embd(ggml_tensor * tok_embd) const;
+    ggml_tensor * build_inp_embd_mtp(ggml_tensor * mtp_tok_embd) const;
     ggml_tensor * build_inp_pos() const;
     ggml_tensor * build_inp_attn_scale() const;
     ggml_tensor * build_inp_out_ids() const;

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -818,3 +818,4 @@ struct llm_graph_context {
 
 // TODO: better name
 int32_t llama_relative_position_bucket(llama_pos x, llama_pos y, uint64_t n_buckets, bool bidirectional);
+

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -417,8 +417,7 @@ struct llm_graph_params {
     const llama_adapter_loras    * loras;
     const llama_memory_context_i * mctx;
     const llama_cross            * cross;
-    bool update_mtp_kv;
-    bool use_mtp_head;
+    llama_mtp_params             mtp_params;
 
     uint32_t n_outputs;
 
@@ -467,8 +466,7 @@ struct llm_graph_params {
             cvec      == other.cvec  &&
             loras     == other.loras &&
             cross     == other.cross &&
-            update_mtp_kv == other.update_mtp_kv &&
-            use_mtp_head  == other.use_mtp_head  &&
+            mtp_params.op_type == other.mtp_params.op_type &&
             n_outputs == other.n_outputs;
     }
 };

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -29,6 +29,7 @@ enum llm_graph_type {
     LLM_GRAPH_TYPE_DEFAULT,
     LLM_GRAPH_TYPE_ENCODER,
     LLM_GRAPH_TYPE_DECODER,
+    LLM_GRAPH_TYPE_DRAFT,
 };
 
 enum llm_ffn_op_type {
@@ -93,6 +94,20 @@ public:
 };
 
 using llm_graph_input_ptr = std::unique_ptr<llm_graph_input_i>;
+
+class llm_graph_input_mtp_states : public llm_graph_input_i {
+public:
+    llm_graph_input_mtp_states()          = default;
+    virtual ~llm_graph_input_mtp_states() = default;
+
+    void set_input(const llama_ubatch * /*ubatch*/) override {}
+
+    bool can_reuse(const llm_graph_params & /*params*/) override {
+        return true;
+    }
+
+    ggml_tensor * states = nullptr;
+};
 
 class llm_graph_input_embd : public llm_graph_input_i {
 public:
@@ -403,6 +418,7 @@ struct llm_graph_params {
     const llama_memory_context_i * mctx;
     const llama_cross            * cross;
     bool update_mtp_kv;
+    bool use_mtp_head;
 
     uint32_t n_outputs;
 
@@ -451,6 +467,8 @@ struct llm_graph_params {
             cvec      == other.cvec  &&
             loras     == other.loras &&
             cross     == other.cross &&
+            update_mtp_kv == other.update_mtp_kv &&
+            use_mtp_head  == other.use_mtp_head  &&
             n_outputs == other.n_outputs;
     }
 };

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -402,6 +402,7 @@ struct llm_graph_params {
     const llama_adapter_loras    * loras;
     const llama_memory_context_i * mctx;
     const llama_cross            * cross;
+    bool update_mtp_kv;
 
     uint32_t n_outputs;
 

--- a/src/llama-kv-cache-unified.cpp
+++ b/src/llama-kv-cache-unified.cpp
@@ -766,7 +766,6 @@ bool llama_kv_cache_unified::update(llama_context * lctx, bool do_shift, const d
 }
 
 llama_kv_cache_unified::slot_info llama_kv_cache_unified::find_slot(const llama_ubatch & ubatch, bool cont) const {
-    LLAMA_LOG_WARN("%s: Entering find_slot for ubatch of %d tokens.\n", __func__, ubatch.n_tokens);
     if (debug > 0) {
         const auto & cells = v_cells[seq_to_stream[1]];
 
@@ -972,9 +971,6 @@ llama_kv_cache_unified::slot_info llama_kv_cache_unified::find_slot(const llama_
                 }
             }
         }
-        LLAMA_LOG_WARN("%s: find_slot SUCCEEDED for ubatch of %d tokens. Idxs:%s\n", __func__, ubatch.n_tokens, idxs_str.c_str());
-    } else {
-        LLAMA_LOG_ERROR("%s: find_slot FAILED to allocate cells for ubatch of %d tokens.\n", __func__, ubatch.n_tokens);
     }
 
     return res;

--- a/src/llama-kv-cache-unified.cpp
+++ b/src/llama-kv-cache-unified.cpp
@@ -41,7 +41,7 @@ llama_kv_cache_unified::llama_kv_cache_unified(
     }
     if (model.arch == LLM_ARCH_GLM4_MOE) {
         // GLM-4.5: Only process up to last layer, skip final NextN layer
-        n_layer_cache = hparams.n_layer - hparams.nextn_predict_layers;
+        n_layer_cache = hparams.n_layer;// - hparams.nextn_predict_layers;
     }
 
     // create a context for each buffer type

--- a/src/llama-kv-cache-unified.cpp
+++ b/src/llama-kv-cache-unified.cpp
@@ -2322,6 +2322,11 @@ bool llama_kv_cache_unified_context::apply() {
     return true;
 }
 
+void llama_kv_cache_unified_context::set_n_kv() {
+    n_kv = kv->get_n_kv();
+}
+
+
 llama_memory_status llama_kv_cache_unified_context::get_status() const {
     return status;
 }
@@ -2382,6 +2387,10 @@ void llama_kv_cache_unified_context::set_input_kq_mask(ggml_tensor * dst, const 
 
 void llama_kv_cache_unified_context::set_input_pos_bucket(ggml_tensor * dst, const llama_ubatch * ubatch) const {
     kv->set_input_pos_bucket(dst, ubatch);
+}
+
+void llama_kv_cache_unified_context::set_sinfos(llama_kv_cache_unified::slot_info_vec_t new_sinfos) {
+    sinfos = new_sinfos;
 }
 
 uint32_t llama_kv_cache_unified::get_padding(const llama_cparams & cparams) {

--- a/src/llama-kv-cache-unified.h
+++ b/src/llama-kv-cache-unified.h
@@ -340,6 +340,7 @@ public:
     //
 
     uint32_t get_n_kv() const;
+    void set_n_kv();
 
     // TODO: temporary
     bool get_supports_set_rows() const;
@@ -361,6 +362,8 @@ public:
     void set_input_k_shift   (ggml_tensor * dst) const;
     void set_input_kq_mask   (ggml_tensor * dst, const llama_ubatch * ubatch, bool causal_attn) const;
     void set_input_pos_bucket(ggml_tensor * dst, const llama_ubatch * ubatch) const;
+
+    void set_sinfos(slot_info_vec_t new_sinfos);
 
 private:
     llama_memory_status status;

--- a/src/llama-kv-cache-unified.h
+++ b/src/llama-kv-cache-unified.h
@@ -116,6 +116,12 @@ public:
             llama_batch_allocr & balloc,
             uint32_t n_ubatch,
             bool embd_all) override;
+    
+    llama_memory_context_ptr init_batch_with_sinfos(
+            llama_batch_allocr & balloc,
+            uint32_t n_ubatch,
+            const slot_info_vec_t & sinfos,
+            bool is_inplace_update);
 
     llama_memory_context_ptr init_full() override;
 
@@ -181,7 +187,7 @@ public:
     slot_info find_slot(const llama_ubatch & ubatch, bool cont) const;
 
     // emplace the ubatch context into slot: [sinfo.idxs[0...ubatch.n_tokens - 1]]
-    void apply_ubatch(const slot_info & sinfo, const llama_ubatch & ubatch);
+    void apply_ubatch(const slot_info & sinfo, const llama_ubatch & ubatch, bool is_inplace_update = false);
 
     //
     // input API
@@ -321,7 +327,8 @@ public:
     llama_kv_cache_unified_context(
             llama_kv_cache_unified * kv,
             slot_info_vec_t sinfos,
-            std::vector<llama_ubatch> ubatches);
+            std::vector<llama_ubatch> ubatches,
+            bool is_inplace_update = false);
 
     virtual ~llama_kv_cache_unified_context();
 
@@ -365,6 +372,8 @@ public:
 
     void set_sinfos(slot_info_vec_t new_sinfos);
 
+    const slot_info_vec_t & get_sinfos() const { return sinfos; }
+
 private:
     llama_memory_status status;
 
@@ -399,4 +408,6 @@ private:
     // a heuristic, to avoid attending the full cache if it is not yet utilized
     // as the cache gets filled, the benefit from this heuristic disappears
     int32_t n_kv;
+
+    bool is_inplace_update = false;
 };

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -13788,6 +13788,13 @@ struct llm_build_glm4 : public llm_graph_context {
 
 struct llm_build_glm4_moe : public llm_graph_context {
     llm_build_glm4_moe(const llama_model & model, const llm_graph_params & params) : llm_graph_context(params) {
+        LLAMA_LOG_WARN(
+            "[GRAPH_BUILD] Building graph. Path: %s, MTP_Update: %s, UBatch_Tokens: %d, First_Pos: %d\n",
+            params.use_mtp_head ? "MTP" : "MAIN",
+            params.update_mtp_kv ? "true" : "false",
+            n_tokens,
+            n_tokens > 0 ? ubatch.pos[0] : -1
+        );
         const int64_t n_embd_head = hparams.n_embd_head_v;
         GGML_ASSERT(n_embd_head == hparams.n_embd_head_k);
 
@@ -13906,7 +13913,10 @@ struct llm_build_glm4_moe : public llm_graph_context {
                     cb(Qcur, "Qcur", il);
                     cb(Kcur, "Kcur", il);
                     cb(Vcur, "Vcur", il);
-
+                    if (ubatch.n_tokens > 0) {
+                        LLAMA_LOG_WARN("[KV_WRITE] path=MAIN, layer=%d, n_tokens=%d, pos_start=%d, pos_end=%d\n",
+                            il, ubatch.n_tokens, ubatch.pos[0], ubatch.pos[ubatch.n_tokens-1]);
+                    }
                     cur = build_attn(inp_attn,
                             model.layers[il].wo, NULL,
                             Qcur, Kcur, Vcur, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
@@ -14060,7 +14070,10 @@ private:
             // LLAMA_LOG_WARN("  - Qcur shape: [%d, %d, %d]\n", Qcur->ne[0], Qcur->ne[1], Qcur->ne[2]);
             // LLAMA_LOG_WARN("  - Kcur shape: [%d, %d, %d]\n", Kcur->ne[0], Kcur->ne[1], Kcur->ne[2]);
             // LLAMA_LOG_WARN("  - Vcur shape: [%d, %d, %d]\n", Vcur->ne[0], Vcur->ne[1], Vcur->ne[2]);
-
+            if (ubatch.n_tokens > 0) {
+                LLAMA_LOG_WARN("[KV_WRITE] path=MTP, layer=%d, n_tokens=%d, pos_start=%d, pos_end=%d\n",
+                    il, ubatch.n_tokens, ubatch.pos[0], ubatch.pos[ubatch.n_tokens-1]);
+            }
             cur = build_attn(inp_attn,
                      mtp_layer.wo, NULL,
                      Qcur, Kcur, Vcur, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -13829,11 +13829,6 @@ struct llm_build_glm4_moe : public llm_graph_context {
             // Final layer tensors are loaded but not processed in forward pass
             const int n_transformer_layers = n_layer - hparams.nextn_predict_layers;
             for (int il = 0; il < n_transformer_layers; ++il) {
-                // if (params.use_mtp_head) {
-                //     LLAMA_LOG_ERROR("[DEBUG-KV-ERROR] MTP path is running the main layer %d!\n", il);
-                // } else {
-                //     LLAMA_LOG_WARN("[DEBUG-KV] Main Head Path: Accessing layer %d\n", il);
-                // }
                 ggml_tensor * inpSA = inpL;
 
                 // Pre-attention norm
@@ -13976,7 +13971,6 @@ private:
         ggml_tensor * embd_copy = ggml_dup(ctx0, prev_embeddings);
 
         const int il = hparams.n_layer - 1;
-        // LLAMA_LOG_WARN("[DEBUG-KV] MTP Head Path: Accessing layer %d\n", il);
         ggml_tensor * sum_node = ggml_sum(ctx0, embd_copy);
 
         ggml_set_name(sum_node, "mtp_input_sum");
@@ -18311,12 +18305,8 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
 }
 
 ggml_cgraph * llama_model::build_graph(const llm_graph_params & params) const {
-    const int64_t t_start_us = ggml_time_us();
     
     std::unique_ptr<llm_graph_context> llm;
-
-    const bool build_mtp = params.mtp_params.op_type == MTP_OP_UPDATE_ACCEPTED;
-
     switch (arch) {
         case LLM_ARCH_LLAMA:
             {
@@ -18678,12 +18668,6 @@ ggml_cgraph * llama_model::build_graph(const llm_graph_params & params) const {
         // add on pooling layer
         llm->build_pooling(cls, cls_b, cls_out, cls_out_b);
     }
-    const int64_t t_end_us = ggml_time_us();
-    // LLAMA_LOG_INFO(
-    //     "[PERF] Graph build time: %.2f ms (MTP path: %s)\n",
-    //     (t_end_us - t_start_us) / 1000.0,
-    //     params.use_mtp_head ? "yes" : "no"
-    // );
     return llm->res->get_gf();
 }
 

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -14100,6 +14100,10 @@ struct llm_build_glm4_moe_mtp : public llm_graph_context {
         res->t_logits = cur;
 
         ggml_build_forward_expand(gf, res->t_logits);
+
+        struct ggml_tensor * token_id_tensor = ggml_argmax(ctx0, cur);
+        ggml_set_name(token_id_tensor, "mtp_argmax_result");
+        ggml_build_forward_expand(gf, token_id_tensor);
     }
 };
 

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -18673,6 +18673,22 @@ ggml_cgraph * llama_model::build_graph(const llm_graph_params & params) const {
     return llm->res->get_gf();
 }
 
+ggml_cgraph* llama_model::build_mtp_graph(const llm_graph_params& params,
+    ggml_tensor* hidden_state_inp, llama_token last_token_id, int n_past) const {
+    std::unique_ptr<llm_graph_context> llm;
+
+    switch (arch) {
+    case LLM_ARCH_GLM4_MOE:
+    {
+        llm = std::make_unique<llm_build_glm4_moe_mtp>(*this, params, hidden_state_inp, last_token_id, n_past);
+    } break;
+    default:
+        GGML_ABORT("fatal error");
+    }
+
+    return llm->res->get_gf();
+}
+
 //
 // interface implementation
 //

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -18587,6 +18587,10 @@ const char * llama_model_cls_label(const struct llama_model * model, uint32_t i)
     return nullptr;
 }
 
+int32_t llama_model_n_nextn_layer(const llama_model * model) {
+    return model->hparams.nextn_predict_layers;
+}
+
 // deprecated
 int32_t llama_n_ctx_train(const llama_model * model) {
     return llama_model_n_ctx_train(model);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -18673,19 +18673,21 @@ ggml_cgraph * llama_model::build_graph(const llm_graph_params & params) const {
     return llm->res->get_gf();
 }
 
-ggml_cgraph* llama_model::build_mtp_graph(const llm_graph_params& params,
+ggml_cgraph * llama_model::build_mtp_graph(const llm_graph_params& params,
     ggml_tensor* hidden_state_inp, llama_token last_token_id, int n_past) const {
     std::unique_ptr<llm_graph_context> llm;
 
     switch (arch) {
     case LLM_ARCH_GLM4_MOE:
     {
+        printf("step: '%d'\n", 56);
         llm = std::make_unique<llm_build_glm4_moe_mtp>(*this, params, hidden_state_inp, last_token_id, n_past);
     } break;
     default:
         GGML_ABORT("fatal error");
     }
 
+    printf("step: '%d'\n", 57);
     return llm->res->get_gf();
 }
 
@@ -19004,3 +19006,11 @@ bool llama_model_is_diffusion(const llama_model * model) {
 const std::vector<std::pair<std::string, ggml_tensor *>> & llama_internal_get_tensor_map(const llama_model * model) {
     return model->tensors_by_name;
 }
+
+ggml_cgraph * llama_build_mtp_graph(const llama_model * model, const llm_graph_params & params,
+    ggml_tensor * hidden_state_inp, llama_token last_token_id, int n_past) {
+    printf("step: '%d'\n", 55);
+
+    return model->build_mtp_graph(params, hidden_state_inp, last_token_id, n_past);
+}
+

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -13793,7 +13793,21 @@ struct llm_build_glm4_moe : public llm_graph_context {
 
         ggml_tensor * cur;
 
-        if (params.mtp_params.op_type != MTP_OP_NONE) {
+        // if (params.mtp_params.op_type != MTP_OP_NONE && params.mtp_params.op_type != MTP_OP_MAIN_VALIDATION) {
+        //     ggml_tensor* hidden_states_from_main_model;
+
+        //     if (params.mtp_params.op_type == MTP_OP_WARMUP || params.mtp_params.op_type == MTP_OP_UPDATE_ACCEPTED) {
+        //         hidden_states_from_main_model = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd, n_tokens);
+        //     } else {
+        //         hidden_states_from_main_model = ggml_new_tensor_1d(ctx0, GGML_TYPE_F32, hparams.n_embd);     
+        //     }
+        //     ggml_set_name(hidden_states_from_main_model, "result_embd_pooled");
+        //     ggml_set_input(hidden_states_from_main_model);
+
+        //     auto inp_mtp = std::make_unique<llm_graph_input_mtp_states>();
+        //     inp_mtp->states = hidden_states_from_main_model;
+        //     res->add_input(std::move(inp_mtp));
+        if (params.mtp_params.op_type != MTP_OP_NONE && params.mtp_params.op_type != MTP_OP_MAIN_VALIDATION) {
             ggml_tensor* hidden_states_from_main_model;
 
             if (params.mtp_params.op_type == MTP_OP_WARMUP || params.mtp_params.op_type == MTP_OP_UPDATE_ACCEPTED) {
@@ -13971,8 +13985,9 @@ private:
         ggml_tensor * embd_copy = ggml_dup(ctx0, prev_embeddings);
 
         const int il = hparams.n_layer - 1;
+        // cb(embd_copy, "mtp_embd_copy", il);
         ggml_tensor * sum_node = ggml_sum(ctx0, embd_copy);
-
+        // cb(sum_node, "mtp_sum_node", il);
         ggml_set_name(sum_node, "mtp_input_sum");
 
         ggml_tensor * inp_pos = build_inp_pos();
@@ -13983,30 +13998,48 @@ private:
         ggml_tensor * hidden_state_norm = build_norm(embd_copy, mtp_layer.nextn.hnorm, NULL, LLM_NORM_RMS, il);
         
         ggml_tensor * combined = ggml_concat(ctx0, token_emb_norm, hidden_state_norm, 0);
+        // cb(combined, "mtp_combined", il);
+
         ggml_tensor* cur = build_lora_mm(mtp_layer.nextn.eh_proj, combined);
 
         // now proceed through last layer (skipped in main model)
         ggml_tensor * inpSA = cur;
         // Pre-attention norm for the MTP block
         cur = build_norm(cur, mtp_layer.attn_norm, NULL, LLM_NORM_RMS, il);
+        // cb(cur, "mtp_attn_norm", il);
 
         // self-attention
         {
             ggml_tensor * Qcur = build_lora_mm(mtp_layer.wq, cur);
+            // if (mtp_layer.bq) {
+            //     Qcur = ggml_add(ctx0, Qcur, mtp_layer.bq);
+            //     cb(Qcur, "mtp_q_bias", il); // ADICIONADO
+            // }
             if (mtp_layer.bq) Qcur = ggml_add(ctx0, Qcur, mtp_layer.bq);
             cb(Qcur, "Qcur", il);
 
             ggml_tensor * Kcur = build_lora_mm(mtp_layer.wk, cur);
+            // if (mtp_layer.bk) {
+            //     Kcur = ggml_add(ctx0, Kcur, mtp_layer.bk);
+            //     cb(Kcur, "mtp_k_bias", il); // ADICIONADO
+            // }
             if (mtp_layer.bk) Kcur = ggml_add(ctx0, Kcur, mtp_layer.bk);
             cb(Kcur, "Kcur", il);
 
             ggml_tensor * Vcur = build_lora_mm(mtp_layer.wv, cur);
+            // if (mtp_layer.bv) {
+            //     Vcur = ggml_add(ctx0, Vcur, mtp_layer.bv);
+            //     cb(Vcur, "mtp_v_bias", il); // ADICIONADO
+            // }
             if (mtp_layer.bv) Vcur = ggml_add(ctx0, Vcur, mtp_layer.bv);
             cb(Vcur, "Vcur", il);
 
             Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head, n_tokens);
+            // cb(Qcur, "mtp_q_reshaped", il);
             Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
+            // cb(Kcur, "mtp_k_reshaped", il);
             Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv, n_tokens);
+            // cb(Vcur, "mtp_v_reshaped", il);
 
             // Apply Q/K norm if available (GLM-4.5 355B variant)
             if (mtp_layer.attn_q_norm) {
@@ -14023,12 +14056,14 @@ private:
                     n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
                     ext_factor, attn_factor, beta_fast, beta_slow
                     );
+            // cb(Qcur, "mtp_q_rope", il);
 
             Kcur = ggml_rope_ext(
                     ctx0, Kcur, inp_pos, nullptr,
                     n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
                     ext_factor, attn_factor, beta_fast, beta_slow
                     );
+            // cb(Kcur, "mtp_k_rope", il);
 
             cb(Qcur, "Qcur", il);
             cb(Kcur, "Kcur", il);
@@ -14040,8 +14075,10 @@ private:
         }
 
         ggml_tensor * ffn_inp = ggml_add(ctx0, cur, inpSA);
+        // cb(ffn_inp, "mtp_ffn_inp", il);
 
         cur = build_norm(ffn_inp, mtp_layer.attn_post_norm, NULL, LLM_NORM_RMS, il);
+        // cb(cur, "post_attn_norm", il);
 
         // moe ffn for nextn block
         {
@@ -14073,7 +14110,10 @@ private:
             cb(cur, "ffn_out", il);
         }
         cur = ggml_add(ctx0, cur, ffn_inp);
+        // cb(cur, "mtp_ffn_residual", il);
+        
         cur = build_norm(cur, mtp_layer.nextn.shared_head_norm, NULL, LLM_NORM_RMS, il);
+        // cb(cur, "mtp_final_norm", il);
         cur = build_lora_mm(mtp_layer.nextn.shared_head_head, cur);
 
         return cur; 
@@ -18305,7 +18345,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
 }
 
 ggml_cgraph * llama_model::build_graph(const llm_graph_params & params) const {
-    
+    const int64_t t_start_us = ggml_time_us();
     std::unique_ptr<llm_graph_context> llm;
     switch (arch) {
         case LLM_ARCH_LLAMA:
@@ -18664,10 +18704,16 @@ ggml_cgraph * llama_model::build_graph(const llm_graph_params & params) const {
             GGML_ABORT("fatal error");
     }
 
-    if (params.mtp_params.op_type == MTP_OP_NONE) {
+    if (params.mtp_params.op_type == MTP_OP_NONE || params.mtp_params.op_type == MTP_OP_MAIN_VALIDATION) {
         // add on pooling layer
         llm->build_pooling(cls, cls_b, cls_out, cls_out_b);
     }
+    const int64_t t_end_us = ggml_time_us();
+    LLAMA_LOG_INFO(
+        "[PERF] Graph build time: %.2f ms (MTP path: %s)\n",
+        (t_end_us - t_start_us) / 1000.0,
+        params.mtp_params.op_type != MTP_OP_NONE || params.mtp_params.op_type != MTP_OP_MAIN_VALIDATION ? "yes" : "no"
+    );
     return llm->res->get_gf();
 }
 

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -13793,47 +13793,21 @@ struct llm_build_glm4_moe : public llm_graph_context {
 
         ggml_tensor * cur;
 
-        // if (params.mtp_params.op_type != MTP_OP_NONE && params.mtp_params.op_type != MTP_OP_MAIN_VALIDATION) {
-        //     ggml_tensor* hidden_states_from_main_model;
-
-        //     if (params.mtp_params.op_type == MTP_OP_WARMUP || params.mtp_params.op_type == MTP_OP_UPDATE_ACCEPTED) {
-        //         hidden_states_from_main_model = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd, n_tokens);
-        //     } else {
-        //         hidden_states_from_main_model = ggml_new_tensor_1d(ctx0, GGML_TYPE_F32, hparams.n_embd);     
-        //     }
-        //     ggml_set_name(hidden_states_from_main_model, "result_embd_pooled");
-        //     ggml_set_input(hidden_states_from_main_model);
-
-        //     auto inp_mtp = std::make_unique<llm_graph_input_mtp_states>();
-        //     inp_mtp->states = hidden_states_from_main_model;
-        //     res->add_input(std::move(inp_mtp));
-        if (params.mtp_params.op_type != MTP_OP_NONE && params.mtp_params.op_type != MTP_OP_MAIN_VALIDATION) {
-            ggml_tensor* hidden_states_from_main_model;
-
-            if (params.mtp_params.op_type == MTP_OP_WARMUP || params.mtp_params.op_type == MTP_OP_UPDATE_ACCEPTED) {
-                hidden_states_from_main_model = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd, n_tokens);
-                ggml_set_name(hidden_states_from_main_model, "result_embd_pooled");
-                ggml_set_input(hidden_states_from_main_model);
-
-                auto inp_mtp = std::make_unique<llm_graph_input_mtp_states>();
-                inp_mtp->states = hidden_states_from_main_model;
-                res->add_input(std::move(inp_mtp));
-            } else {
-                    hidden_states_from_main_model = ggml_new_tensor_1d(ctx0, GGML_TYPE_F32, hparams.n_embd);
-                    ggml_set_name(hidden_states_from_main_model, "result_embd_pooled");
-                    ggml_set_input(hidden_states_from_main_model);
-
-                    auto inp_mtp = std::make_unique<llm_graph_input_mtp_states>();
-                    inp_mtp->states = hidden_states_from_main_model;
-                    res->add_input(std::move(inp_mtp));
-            }
+        if (params.mtp_params.op_type == MTP_OP_DRAFT_ONLY) {
+            ggml_tensor * hidden_state_input = ggml_new_tensor_1d(ctx0, GGML_TYPE_F32, hparams.n_embd);
+            ggml_set_name(hidden_state_input, "mtp_draft_hidden_state");
+            ggml_set_input(hidden_state_input);
+            auto inp_mtp = std::make_unique<llm_graph_input_mtp_states>();
+            inp_mtp->states = hidden_state_input;
+            res->add_input(std::move(inp_mtp));
 
             const int il_mtp = hparams.n_layer - 1;
             const auto & mtp_layer = model.layers[il_mtp];
-            res->t_logits = build_mtp_tail(mtp_layer, hidden_states_from_main_model, n_embd_head);
+            res->t_logits = build_mtp_draft_graph(mtp_layer, hidden_state_input, n_embd_head);
 
         } else {
-            ggml_tensor * inpL = build_inp_embd(model.tok_embd);
+            ggml_tensor * inp_raw_embd = build_inp_embd(model.tok_embd);
+            ggml_tensor * inpL = inp_raw_embd; 
             // inp_pos - contains the positions
             ggml_tensor * inp_pos = build_inp_pos();
             auto * inp_attn = build_attn_inp_kv_unified();
@@ -13970,125 +13944,137 @@ struct llm_build_glm4_moe : public llm_graph_context {
             // cb(cur, "result_norm", -1);
             res->t_embd = cur;
 
-        // Use the main model header
-        res->t_logits = build_lora_mm(model.output, cur);
+            if (params.mtp_params.op_type == MTP_OP_UNIFIED) {
+                const int il_mtp = hparams.n_layer - 1;
+                const auto & mtp_layer = model.layers[il_mtp];
+
+                ggml_tensor * mtp_embd_input = inp_raw_embd;
+
+                if (inp_out_ids) {
+                    mtp_embd_input = ggml_get_rows(ctx0, inp_raw_embd, inp_out_ids);
+                    ggml_set_name(mtp_embd_input, "mtp_sliced_embd"); 
+                }
+
+                build_mtp_update_graph(mtp_layer, cur, mtp_embd_input, inp_pos, inp_attn, n_embd_head);
+            }
+
+            // Use the main model header
+            res->t_logits = build_lora_mm(model.output, cur);
+
         }
 
-    ggml_build_forward_expand(gf, res->t_logits);
-
+        ggml_build_forward_expand(gf, res->t_logits);
     }
 
 private:
-    ggml_tensor * build_mtp_tail(const llama_layer & mtp_layer, ggml_tensor * prev_embeddings,
-        int64_t n_embd_head
-    ) {
-        ggml_tensor * embd_copy = ggml_dup(ctx0, prev_embeddings);
-
+    ggml_tensor * build_mtp_draft_graph(const llama_layer & mtp_layer, ggml_tensor * hidden_state_input, int64_t n_embd_head) {
         const int il = hparams.n_layer - 1;
-        // cb(embd_copy, "mtp_embd_copy", il);
-        ggml_tensor * sum_node = ggml_sum(ctx0, embd_copy);
-        // cb(sum_node, "mtp_sum_node", il);
-        ggml_set_name(sum_node, "mtp_input_sum");
+
+        ggml_tensor * token_emb = build_inp_embd_mtp(mtp_layer.nextn.embed_tokens);
+        ggml_tensor * hidden_state_norm = build_norm(hidden_state_input, mtp_layer.nextn.hnorm, NULL, LLM_NORM_RMS, il);
+        ggml_tensor * token_emb_norm = build_norm(token_emb, mtp_layer.nextn.enorm, NULL, LLM_NORM_RMS, il);
+        ggml_tensor * combined = ggml_concat(ctx0, token_emb_norm, hidden_state_norm, 0);
+        ggml_tensor * projected_input = build_lora_mm(mtp_layer.nextn.eh_proj, combined);
 
         ggml_tensor * inp_pos = build_inp_pos();
         auto * inp_attn = build_attn_inp_kv_unified();
-        ggml_tensor * token_emb = build_inp_embd_mtp(mtp_layer.nextn.embed_tokens);
 
-        ggml_tensor * token_emb_norm = build_norm(token_emb, mtp_layer.nextn.enorm, NULL, LLM_NORM_RMS, il);
-        ggml_tensor * hidden_state_norm = build_norm(embd_copy, mtp_layer.nextn.hnorm, NULL, LLM_NORM_RMS, il);
+        ggml_tensor* final_state = build_transformer_block(mtp_layer, projected_input, inp_pos, inp_attn, n_embd_head, il);
         
+        ggml_tensor* logits = build_norm(final_state, mtp_layer.nextn.shared_head_norm, NULL, LLM_NORM_RMS, il);
+        logits = build_lora_mm(mtp_layer.nextn.shared_head_head, logits);
+
+        return logits;
+    }
+
+    void build_mtp_update_graph(
+        const llama_layer & mtp_layer, 
+        ggml_tensor * main_model_hidden_state,
+        ggml_tensor * main_model_token_emb,
+        ggml_tensor * inp_pos, 
+        llm_graph_input_attn_kv_unified * inp_attn, 
+        int64_t n_embd_head
+    ) {
+        const int il = hparams.n_layer - 1;
+
+        ggml_tensor * hidden_state_norm = build_norm(main_model_hidden_state, mtp_layer.nextn.hnorm, NULL, LLM_NORM_RMS, il);
+        ggml_tensor * token_emb_norm = build_norm(main_model_token_emb, mtp_layer.nextn.enorm, NULL, LLM_NORM_RMS, il);
         ggml_tensor * combined = ggml_concat(ctx0, token_emb_norm, hidden_state_norm, 0);
-        // cb(combined, "mtp_combined", il);
+        ggml_tensor * projected_input = build_lora_mm(mtp_layer.nextn.eh_proj, combined);
 
-        ggml_tensor* cur = build_lora_mm(mtp_layer.nextn.eh_proj, combined);
+        build_transformer_block(mtp_layer, projected_input, inp_pos, inp_attn, n_embd_head, il);
+        
+        ggml_tensor * dummy_output = ggml_sum(ctx0, main_model_hidden_state);
+        ggml_set_name(dummy_output, "mtp_update_side_effect");
+    }
 
+    ggml_tensor * llm_build_glm4_moe::build_transformer_block(const llama_layer & layer, ggml_tensor* input, 
+        ggml_tensor* current_pos,
+        llm_graph_input_attn_kv_unified* current_inp_attn, int64_t n_embd_head, int il) {
         // now proceed through last layer (skipped in main model)
-        ggml_tensor * inpSA = cur;
+        ggml_tensor * inpSA = input;
         // Pre-attention norm for the MTP block
-        cur = build_norm(cur, mtp_layer.attn_norm, NULL, LLM_NORM_RMS, il);
-        // cb(cur, "mtp_attn_norm", il);
+        ggml_tensor* cur = build_norm(input, layer.attn_norm, NULL, LLM_NORM_RMS, il);
 
         // self-attention
         {
-            ggml_tensor * Qcur = build_lora_mm(mtp_layer.wq, cur);
-            // if (mtp_layer.bq) {
-            //     Qcur = ggml_add(ctx0, Qcur, mtp_layer.bq);
-            //     cb(Qcur, "mtp_q_bias", il); // ADICIONADO
-            // }
-            if (mtp_layer.bq) Qcur = ggml_add(ctx0, Qcur, mtp_layer.bq);
+            ggml_tensor * Qcur = build_lora_mm(layer.wq, cur);
+            if (layer.bq) Qcur = ggml_add(ctx0, Qcur, layer.bq);
             cb(Qcur, "Qcur", il);
 
-            ggml_tensor * Kcur = build_lora_mm(mtp_layer.wk, cur);
-            // if (mtp_layer.bk) {
-            //     Kcur = ggml_add(ctx0, Kcur, mtp_layer.bk);
-            //     cb(Kcur, "mtp_k_bias", il); // ADICIONADO
-            // }
-            if (mtp_layer.bk) Kcur = ggml_add(ctx0, Kcur, mtp_layer.bk);
+            ggml_tensor * Kcur = build_lora_mm(layer.wk, cur);
+            if (layer.bk) Kcur = ggml_add(ctx0, Kcur, layer.bk);
             cb(Kcur, "Kcur", il);
 
-            ggml_tensor * Vcur = build_lora_mm(mtp_layer.wv, cur);
-            // if (mtp_layer.bv) {
-            //     Vcur = ggml_add(ctx0, Vcur, mtp_layer.bv);
-            //     cb(Vcur, "mtp_v_bias", il); // ADICIONADO
-            // }
-            if (mtp_layer.bv) Vcur = ggml_add(ctx0, Vcur, mtp_layer.bv);
+            ggml_tensor * Vcur = build_lora_mm(layer.wv, cur);
+            if (layer.bv) Vcur = ggml_add(ctx0, Vcur, layer.bv);
             cb(Vcur, "Vcur", il);
 
             Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head, n_tokens);
-            // cb(Qcur, "mtp_q_reshaped", il);
             Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
-            // cb(Kcur, "mtp_k_reshaped", il);
             Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv, n_tokens);
-            // cb(Vcur, "mtp_v_reshaped", il);
 
             // Apply Q/K norm if available (GLM-4.5 355B variant)
-            if (mtp_layer.attn_q_norm) {
-                Qcur = build_norm(Qcur, mtp_layer.attn_q_norm, NULL, LLM_NORM_RMS, il);
+            if (layer.attn_q_norm) {
+                Qcur = build_norm(Qcur, layer.attn_q_norm, NULL, LLM_NORM_RMS, il);
                 cb(Qcur, "Qcur_normed", il);
             }
-            if (mtp_layer.attn_k_norm) {
-                Kcur = build_norm(Kcur, mtp_layer.attn_k_norm, NULL, LLM_NORM_RMS, il);
+            if (layer.attn_k_norm) {
+                Kcur = build_norm(Kcur, layer.attn_k_norm, NULL, LLM_NORM_RMS, il);
                 cb(Kcur, "Kcur_normed", il);
             }
 
             Qcur = ggml_rope_ext(
-                    ctx0, Qcur, inp_pos, nullptr,
+                    ctx0, Qcur, current_pos, nullptr,
                     n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
                     ext_factor, attn_factor, beta_fast, beta_slow
                     );
-            // cb(Qcur, "mtp_q_rope", il);
 
             Kcur = ggml_rope_ext(
-                    ctx0, Kcur, inp_pos, nullptr,
+                    ctx0, Kcur, current_pos, nullptr,
                     n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
                     ext_factor, attn_factor, beta_fast, beta_slow
                     );
-            // cb(Kcur, "mtp_k_rope", il);
 
             cb(Qcur, "Qcur", il);
             cb(Kcur, "Kcur", il);
             cb(Vcur, "Vcur", il);
 
-            cur = build_attn(inp_attn,
-                     mtp_layer.wo, NULL,
-                     Qcur, Kcur, Vcur, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
+            cur = build_attn(current_inp_attn, layer.wo, NULL, Qcur, Kcur, Vcur, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
         }
 
         ggml_tensor * ffn_inp = ggml_add(ctx0, cur, inpSA);
-        // cb(ffn_inp, "mtp_ffn_inp", il);
-
-        cur = build_norm(ffn_inp, mtp_layer.attn_post_norm, NULL, LLM_NORM_RMS, il);
-        // cb(cur, "post_attn_norm", il);
+        cur = build_norm(ffn_inp, layer.attn_post_norm, NULL, LLM_NORM_RMS, il);
 
         // moe ffn for nextn block
         {
             // Process routed experts using existing MoE infrastructure
             ggml_tensor * routed_out = build_moe_ffn(cur,
-                    mtp_layer.ffn_gate_inp,
-                    mtp_layer.ffn_up_exps,
-                    mtp_layer.ffn_gate_exps,
-                    mtp_layer.ffn_down_exps,
-                    mtp_layer.ffn_exp_probs_b,
+                    layer.ffn_gate_inp,
+                    layer.ffn_up_exps,
+                    layer.ffn_gate_exps,
+                    layer.ffn_down_exps,
+                    layer.ffn_exp_probs_b,
                     n_expert, n_expert_used,
                     LLM_FFN_SILU, hparams.expert_weights_norm,
                     true, hparams.expert_weights_scale,
@@ -14098,9 +14084,9 @@ private:
 
             // Process shared expert on original input
             ggml_tensor * shared_out = build_ffn(cur,
-                    mtp_layer.ffn_up_shexp,   NULL, NULL,
-                    mtp_layer.ffn_gate_shexp, NULL, NULL,
-                    mtp_layer.ffn_down_shexp, NULL, NULL,
+                    layer.ffn_up_shexp,   NULL, NULL,
+                    layer.ffn_gate_shexp, NULL, NULL,
+                    layer.ffn_down_shexp, NULL, NULL,
                     NULL,
                     LLM_FFN_SILU, LLM_FFN_PAR, il);
             cb(shared_out, "ffn_shexp_out", il);
@@ -14111,12 +14097,8 @@ private:
         }
         cur = ggml_add(ctx0, cur, ffn_inp);
         // cb(cur, "mtp_ffn_residual", il);
-        
-        cur = build_norm(cur, mtp_layer.nextn.shared_head_norm, NULL, LLM_NORM_RMS, il);
-        // cb(cur, "mtp_final_norm", il);
-        cur = build_lora_mm(mtp_layer.nextn.shared_head_head, cur);
 
-        return cur; 
+        return cur;
     }
 };
 
@@ -18704,7 +18686,7 @@ ggml_cgraph * llama_model::build_graph(const llm_graph_params & params) const {
             GGML_ABORT("fatal error");
     }
 
-    if (params.mtp_params.op_type == MTP_OP_NONE || params.mtp_params.op_type == MTP_OP_MAIN_VALIDATION) {
+    if (params.mtp_params.op_type == MTP_OP_NONE || params.mtp_params.op_type == MTP_OP_UNIFIED) {
         // add on pooling layer
         llm->build_pooling(cls, cls_b, cls_out, cls_out_b);
     }
@@ -18712,7 +18694,7 @@ ggml_cgraph * llama_model::build_graph(const llm_graph_params & params) const {
     LLAMA_LOG_INFO(
         "[PERF] Graph build time: %.2f ms (MTP path: %s)\n",
         (t_end_us - t_start_us) / 1000.0,
-        params.mtp_params.op_type != MTP_OP_NONE || params.mtp_params.op_type != MTP_OP_MAIN_VALIDATION ? "yes" : "no"
+        params.mtp_params.op_type != MTP_OP_NONE || params.mtp_params.op_type != MTP_OP_UNIFIED ? "yes" : "no"
     );
     return llm->res->get_gf();
 }

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -475,7 +475,6 @@ struct llama_model {
 
     // TODO: move this to new llm_arch_model_i interface
     ggml_cgraph * build_graph(const llm_graph_params & params) const;
-    ggml_cgraph * build_mtp_graph(const llm_graph_params& params) const;
 
 private:
     struct impl;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -475,8 +475,7 @@ struct llama_model {
 
     // TODO: move this to new llm_arch_model_i interface
     ggml_cgraph * build_graph(const llm_graph_params & params) const;
-    ggml_cgraph * build_mtp_graph(const llm_graph_params & params,
-        llama_token last_token_id, int n_past) const;
+    ggml_cgraph * build_mtp_graph(const llm_graph_params& params) const;
 
 private:
     struct impl;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -475,6 +475,8 @@ struct llama_model {
 
     // TODO: move this to new llm_arch_model_i interface
     ggml_cgraph * build_graph(const llm_graph_params & params) const;
+    ggml_cgraph * build_mtp_graph(const llm_graph_params & params,
+        ggml_tensor * hidden_state_inp, llama_token last_token_id, int n_past) const;
 
 private:
     struct impl;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -476,7 +476,7 @@ struct llama_model {
     // TODO: move this to new llm_arch_model_i interface
     ggml_cgraph * build_graph(const llm_graph_params & params) const;
     ggml_cgraph * build_mtp_graph(const llm_graph_params & params,
-        ggml_tensor * hidden_state_inp, llama_token last_token_id, int n_past) const;
+        llama_token last_token_id, int n_past) const;
 
 private:
     struct impl;

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -3520,11 +3520,10 @@ struct server_context {
                     needs_mtp_warmup = true;
                 }
             }
-
+            
             if (needs_mtp_warmup) {
-                if (llama_mtp_prepare_sinfo_for_update(ctx, batch_view.n_tokens)) {
+                if (llama_mtp_prepare_sinfo_for_warmup(ctx)) {
                     mtp_update_kv_cache(ctx, batch_view, true);
-
                     llama_mtp_cancel_sinfo_update(ctx);
                 } else {
                     LOG_ERR("%s: Failed to prepare the MTP symphony for warmup.", __func__);

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -3387,6 +3387,15 @@ struct server_context {
                         slot.n_prompt_tokens_processed += n_pos;
                     }
 
+                    const size_t n_to_log = slot.mtp_kv_update_batch.size();
+                    if (n_to_log > 0) {
+                        SLT_INF(slot,
+                            "DEBUG-KV-REQ Cache Warm-up: Requesting KV update for %zu tokens. Positions: %d ... %d\n",
+                            n_to_log,
+                            slot.mtp_kv_update_batch.front().n_past,
+                            slot.mtp_kv_update_batch.back().n_past
+                        );
+                    }
                     // add prompt tokens for processing in the current batch
                     while (slot.n_past < slot.n_prompt_tokens && batch.n_tokens < n_batch) {
                         // get next token to process
@@ -3517,12 +3526,12 @@ struct server_context {
                 continue; // continue loop of n_batch
             }
 
-            for (auto & slot : slots) {
-                // This should only trigger on a non-empty update batch once, after prompt processing but not during token generation
-                if (slot.has_mtp) {
-                    mtp_update_kv_cache(ctx, slot.mtp_kv_update_batch, i, n_tokens);
-               }
-            }
+            // for (auto & slot : slots) {
+            //     // This should only trigger on a non-empty update batch once, after prompt processing but not during token generation
+            //     if (slot.has_mtp) {
+            //         mtp_update_kv_cache(ctx, slot.mtp_kv_update_batch, i, n_tokens);
+            //    }
+            // }
 
             // move the head of the batch forward with the number of tokens we just processed
             i_next = i + n_tokens;

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -1739,7 +1739,7 @@ struct server_queue {
 
         while (true) {
             QUE_DBG("%s", "processing new tasks\n");
-
+            const int64_t t_turn_start_us = ggml_time_us();
             while (true) {
                 std::unique_lock<std::mutex> lock(mutex_tasks);
                 if (!running) {
@@ -1762,7 +1762,11 @@ struct server_queue {
             QUE_DBG("%s", "update slots\n");
 
             callback_update_slots();
-
+            const int64_t t_turn_end_us = ggml_time_us();
+            SRV_DBG(
+                "[PERF] Server turn time: %.2f ms\n",
+                (t_turn_end_us - t_turn_start_us) / 1000.0
+            );
             QUE_DBG("%s", "waiting for new tasks\n");
             {
                 std::unique_lock<std::mutex> lock(mutex_tasks);

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -3520,7 +3520,7 @@ struct server_context {
                     // Clean up the forced state to not affect subsequent decodes.
                     llama_mtp_cancel_sinfo_update(ctx);
                 } else {
-                    LOG_ERR("%s: Failed to prepare the MTP symphony for warmup.", __func__);
+                    LOG_ERR("%s: Failed to prepare the MTP for warmup.", __func__);
                 }
             }
 

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -1432,7 +1432,7 @@ struct server_slot {
     }
 
     bool can_speculate() const {
-        return ctx_dft && params.speculative.n_max > 0 && params.cache_prompt;
+        return (ctx_dft || has_mtp) && params.speculative.n_max > 0 && params.cache_prompt;
     }
 
     void add_token(const completion_token_output & token) {
@@ -2122,14 +2122,16 @@ struct server_context {
                     common_speculative_add_replacement_tgt_dft(slot.spec, pair.first.c_str(), pair.second.c_str());
                 }
             }
+            
+            // if model has MTP and no draft model is specified...
             else if (llama_model_n_nextn_layer(model) > 0) {
-              SRV_INF("model has nextn layers = %d\n", llama_model_n_nextn_layer(model));
-              slot.has_mtp = true;
-              
-              // assume one speculative token (true of all well-known MTP models so far)
-              slot.batch_spec = llama_batch_init(2, 0, 1);
-              params_base.speculative.n_min = 0;
-              params_base.speculative.n_max = 1;
+                SRV_INF("model has nextn layers = %d\n", llama_model_n_nextn_layer(model));
+                slot.has_mtp = true;
+                
+                // assume one speculative token (true of all well-known MTP models so far)
+                slot.batch_spec = llama_batch_init(2, 0, 1);
+                params_base.speculative.n_min = 0;
+                params_base.speculative.n_max = 1;
             }
 
             SLT_INF(slot, "new slot n_ctx_slot = %d\n", slot.n_ctx);

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -3543,17 +3543,18 @@ struct server_context {
 
                 const int tok_idx = slot.i_batch - i;
 
-                // This should only trigger on a non-empty update batch once, after prompt processing but not during token generation
-                if (slot.has_mtp) {
-                    mtp_update_kv_cache(ctx, slot.mtp_kv_update_batch);
-                }
-
                 llama_token id = common_sampler_sample(slot.smpl, ctx, tok_idx);
                 slot.last_tok_idx = tok_idx;
+                SRV_INF("main loop sampled token: '%s'\n", common_token_to_piece(ctx, id, true).c_str());
 
                 slot.i_batch = -1;
 
                 common_sampler_accept(slot.smpl, id, true);
+
+                // This should only trigger on a non-empty update batch once, after prompt processing but not during token generation
+                if (slot.has_mtp) {
+                    mtp_update_kv_cache(ctx, slot.mtp_kv_update_batch);
+                }
 
                 slot.n_decoded += 1;
 

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -1432,7 +1432,8 @@ struct server_slot {
     }
 
     bool can_speculate() const {
-        return (ctx_dft || has_mtp) && params.speculative.n_max > 0 && params.cache_prompt;
+        // return (ctx_dft || has_mtp) && params.speculative.n_max > 0 && params.cache_prompt;
+        return (ctx_dft) && params.speculative.n_max > 0 && params.cache_prompt;
     }
 
     void add_token(const completion_token_output & token) {

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -1294,7 +1294,8 @@ struct server_slot {
     mtmd_context * mctx = nullptr;
 
     common_speculative * spec = nullptr;
-
+    bool has_mtp = false;    
+    
     std::vector<common_adapter_lora_info> lora;
 
     // the index relative to completion multi-task request
@@ -2120,6 +2121,15 @@ struct server_context {
                 for (auto &pair : params_base.speculative.replacements) {
                     common_speculative_add_replacement_tgt_dft(slot.spec, pair.first.c_str(), pair.second.c_str());
                 }
+            }
+            else if (llama_model_n_nextn_layer(model) > 0) {
+              SRV_INF("model has nextn layers = %d\n", llama_model_n_nextn_layer(model));
+              slot.has_mtp = true;
+              
+              // assume one speculative token (true of all well-known MTP models so far)
+              slot.batch_spec = llama_batch_init(2, 0, 1);
+              params_base.speculative.n_min = 0;
+              params_base.speculative.n_max = 1;
             }
 
             SLT_INF(slot, "new slot n_ctx_slot = %d\n", slot.n_ctx);

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -3545,7 +3545,7 @@ struct server_context {
 
                 llama_token id = common_sampler_sample(slot.smpl, ctx, tok_idx);
                 slot.last_tok_idx = tok_idx;
-                SRV_INF("main loop sampled token: '%s'\n", common_token_to_piece(ctx, id, true).c_str());
+                //SRV_INF("main loop sampled token: '%s'\n", common_token_to_piece(ctx, id, true).c_str());
 
                 slot.i_batch = -1;
 

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -3470,6 +3470,7 @@ struct server_context {
             };
 
             const int64_t t_prompt_main_start_us = ggml_time_us();
+            batch_view.mtp_params.op_type = MTP_OP_UNIFIED; // TODO: Apply only for when the model have mtp
             const int ret = llama_decode(ctx, batch_view);
             const int64_t t_prompt_main_end_us = ggml_time_us();
             LOG_INF("[PERF-PROMPT] Main model prompt processing: %.2f ms\n", (t_prompt_main_end_us - t_prompt_main_start_us) / 1000.0);
@@ -3513,24 +3514,6 @@ struct server_context {
                 continue; // continue loop of n_batch
             }
 
-            if (slot_batched && slot_batched->has_mtp &&
-                (slot_batched->state == SLOT_STATE_PROCESSING_PROMPT || slot_batched->state == SLOT_STATE_DONE_PROMPT)) {
-
-                // Prepare the context to reuse the exact sinfo layout (including multiple u-batches)
-                // from the main model's prompt processing pass. This ensures the MTP layer's
-                // KV cache is perfectly aligned.
-                if (llama_mtp_prepare_sinfo_for_warmup(ctx)) {
-                    const int64_t t_warmup_start_us = ggml_time_us();
-                    mtp_update_kv_cache(ctx, batch_view, true);
-                    const int64_t t_warmup_end_us = ggml_time_us();
-                    LOG_INF("[PERF-PROMPT] MTP warm-up: %.2f ms\n", (t_warmup_end_us - t_warmup_start_us) / 1000.0);
-                    // Clean up the forced state to not affect subsequent decodes.
-                    llama_mtp_cancel_sinfo_update(ctx);
-                } else {
-                    LOG_ERR("%s: Failed to prepare the MTP for warmup.", __func__);
-                }
-            }
-
             // move the head of the batch forward with the number of tokens we just processed
             i_next = i + n_tokens;
 
@@ -3565,10 +3548,7 @@ struct server_context {
                 }
 
                 const int tok_idx = slot.i_batch - i;
-                // Sets the initial state for the first draft generation.
-                if (slot.has_mtp) {
-                    llama_set_draft_input_hidden_state(ctx, llama_get_embeddings_ith(ctx, -1));
-                }
+
                 llama_token id = common_sampler_sample(slot.smpl, ctx, tok_idx);
                 slot.last_tok_idx = tok_idx;
 
@@ -3645,13 +3625,6 @@ struct server_context {
                 llama_tokens draft;
                 // const int64_t t_spec_start_us = ggml_time_us();
                 if (slot.has_mtp) {
-                    if (!slot.ids_prev_accepted.empty()) {
-                        LOG_INF("[MTP-FLOW] Updating KV cache with %zu tokens from the previous cycle.\n", slot.ids_prev_accepted.size());
-                        const int32_t n_past_base_update = slot.n_past - slot.ids_prev_accepted.size();
-                        mtp_accept_tokens(ctx, slot.ids_prev_accepted, n_past_base_update, slot.id);
-                        slot.ids_prev_accepted.clear();
-                    }
-
                     llama_set_draft_input_hidden_state(ctx, llama_get_embeddings_ith(ctx, -1));
 
                     LOG_INF("[MTP-FLOW] Generating a new draft from the token %d in the position %d.\n", id, slot.n_past);
@@ -3690,7 +3663,7 @@ struct server_context {
 
                 SLT_DBG(slot, "decoding speculative batch, size = %d\n", slot.batch_spec.n_tokens);
                 const int64_t t_valid_start_us = ggml_time_us();
-                // slot.batch_spec.mtp_params.op_type = MTP_OP_MAIN_VALIDATION;
+                slot.batch_spec.mtp_params.op_type = MTP_OP_UNIFIED;
                 llama_decode(ctx, slot.batch_spec);
                 const int64_t t_valid_end_us = ggml_time_us();
 

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -1366,6 +1366,7 @@ struct server_slot {
     // Speculative decoding stats
     int32_t n_draft_total = 0;      // Total draft tokens generated
     int32_t n_draft_accepted = 0;   // Draft tokens actually accepted
+    llama_tokens ids_prev_accepted; 
 
     void reset() {
         SLT_DBG(*this, "%s", "\n");
@@ -3468,7 +3469,10 @@ struct server_context {
                 batch.logits   + i,
             };
 
+            const int64_t t_prompt_main_start_us = ggml_time_us();
             const int ret = llama_decode(ctx, batch_view);
+            const int64_t t_prompt_main_end_us = ggml_time_us();
+            LOG_INF("[PERF-PROMPT] Main model prompt processing: %.2f ms\n", (t_prompt_main_end_us - t_prompt_main_start_us) / 1000.0);
 
             metrics.on_decoded(slots);
 
@@ -3516,7 +3520,10 @@ struct server_context {
                 // from the main model's prompt processing pass. This ensures the MTP layer's
                 // KV cache is perfectly aligned.
                 if (llama_mtp_prepare_sinfo_for_warmup(ctx)) {
+                    const int64_t t_warmup_start_us = ggml_time_us();
                     mtp_update_kv_cache(ctx, batch_view, true);
+                    const int64_t t_warmup_end_us = ggml_time_us();
+                    LOG_INF("[PERF-PROMPT] MTP warm-up: %.2f ms\n", (t_warmup_end_us - t_warmup_start_us) / 1000.0);
                     // Clean up the forced state to not affect subsequent decodes.
                     llama_mtp_cancel_sinfo_update(ctx);
                 } else {
@@ -3636,9 +3643,19 @@ struct server_context {
                 llama_token id = slot.sampled;
 
                 llama_tokens draft;
+                // const int64_t t_spec_start_us = ggml_time_us();
                 if (slot.has_mtp) {
+                    if (!slot.ids_prev_accepted.empty()) {
+                        LOG_INF("[MTP-FLOW] Updating KV cache with %zu tokens from the previous cycle.\n", slot.ids_prev_accepted.size());
+                        const int32_t n_past_base_update = slot.n_past - slot.ids_prev_accepted.size();
+                        mtp_accept_tokens(ctx, slot.ids_prev_accepted, n_past_base_update, slot.id);
+                        slot.ids_prev_accepted.clear();
+                    }
+
+                    llama_set_draft_input_hidden_state(ctx, llama_get_embeddings_ith(ctx, -1));
+
+                    LOG_INF("[MTP-FLOW] Generating a new draft from the token %d in the position %d.\n", id, slot.n_past);
                     llama_token draft_id = mtp_speculative_gen_draft(slot.smpl, ctx, id, slot.n_past, slot.last_tok_idx);
-                    draft.reserve(1);
                     draft.push_back(draft_id);
                 }
                 else {
@@ -3672,22 +3689,17 @@ struct server_context {
                 }
 
                 SLT_DBG(slot, "decoding speculative batch, size = %d\n", slot.batch_spec.n_tokens);
+                const int64_t t_valid_start_us = ggml_time_us();
+                // slot.batch_spec.mtp_params.op_type = MTP_OP_MAIN_VALIDATION;
                 llama_decode(ctx, slot.batch_spec);
+                const int64_t t_valid_end_us = ggml_time_us();
 
                 // the accepted tokens from the speculation
+                const int64_t t_accept_start_us = ggml_time_us();
                 const auto ids = common_sampler_sample_and_accept_n(slot.smpl, ctx, draft);
-                
-                if (slot.has_mtp) {
-                    llama_set_draft_input_hidden_state(ctx, llama_get_embeddings_ith(ctx, ids.size() - 1));
+                const int64_t t_accept_end_us = ggml_time_us();
 
-                    if (!ids.empty()) {
-                        llama_set_draft_input_hidden_state(ctx, llama_get_embeddings_ith(ctx, ids.size() - 1));
-                    } else {
-                        llama_set_draft_input_hidden_state(ctx, llama_get_embeddings_ith(ctx, 0));
-                    }
-
-                    mtp_accept_tokens(ctx, ids, slot.n_past, slot.id);
-                }
+                slot.ids_prev_accepted = ids;
 
                 slot.n_past    += ids.size();
                 slot.n_decoded += ids.size();


### PR DESCRIPTION

 I've created this draft to share my findings on what to fix or improve to make MTP usable. Currently, MTP's output quality is good, but its performance is worse than not using it at all. Therefore, it's not enough to be on par with the baseline; we need to be faster.

 My initial plan is to find areas for improvement. It's not necessary to implement everything at once, but some of these should be on our radar for the future. They are:
 1) Graph reuse
 2) `llama_context::decode` calls
 3) Multi-token drafts

 There are likely more things to improve, but for now, I find these to be the most impactful. Below are my thoughts on each:

 **1) Graph Reuse:** The baseline implementation always reuses the graph. The process is simple: it stores the graph, and in the next call to `llama_context::process_ubatch`, it checks if the stored graph can be reused. If not, it's deleted and the new one is stored. This works well after the first token is generated, as subsequent graphs are identical. The main bottleneck isn't calling `llama_model::build_graph` constantly, but rather `ggml_backend_sched_alloc_graph`, which has to allocate and compute resources for the backend.

 The first fix was simple: just store one graph. In this case, the main model's token generation graph, which is one of the most expensive, will always be reused. On my machine, this gave an uplift of 13.8% for small prompts.

 **Current state: Halted.**

 After that, I tried to store the graph for every operation, or at least the ones that didn't involve the KV cache. By applying `llm_graph_context::cb` to certain layers, I could store and reuse the graph, and I was able to compile and test this using only the CPU backend. However, I was unable to get it working with the offload policy. In theory, the `cb` function should handle that, but something else seems to be preventing specifically the allocation and computation. Is it mixing the offload policies of the main model and the MTP? This needs a deeper investigation, and I lack the proper knowledge in this area, so I'm setting it aside for now.

 **2) `decode` calls:** MTP was successfully implemented inside `decode`, but it uses the old logic where each operation requires an expensive function call. Here is a comparison of how many calls we make in different scenarios:

 *   **LLM - Normal:**
     *   Loop 1: Prompt + Generation = 1 call
     *   Loop 2: Token generation = 1 call

 *   **Draft Model:**
     *   Loop 1: Prompt + Generation -> Draft generation -> Main model validation = 3 calls
     *   Loop 2: Token generation -> Draft generation -> Main model validation = 3 calls

 *   **MTP (Current Slow Implementation):**
     *   Loop 1: Prompt + Generation -> MTP warmup -> MTP draft -> Main model validation -> MTP KV update = 5 calls
     *   Loop 2: Token generation -> MTP draft -> Main model validation -> MTP KV update = 4 calls

 One way to make MTP more usable is to match the number of calls of a typical draft model. To do that, it's necessary to combine the KV cache update and the draft generation into a single call.

 **Current state: In progress.**

 I successfully merged the KV cache update with the draft generation. This required creating a custom batch and sinfo, and changing some logic regarding the embeddings and hidden states necessary for the MTP to work. The version in this branch works in terms of output, meaning it's not breaking quality. However, the draft acceptance rate has dropped to around 25%. I believe this happens because while the first step (KV update) works using the correct hidden state from the main model, the subsequent operation (draft) is using a new hidden state generated by the MTP itself during the update. I still need to confirm this theory and apply a fix to hopefully see the acceptance rate rise back to its previous level.

 One last thing: this change will still require a separate warmup call on the first interaction, but this is less impactful than merging the update and draft steps. To merge the warmup step, it would be necessary to track the sinfo to know when the prompt processing has finished its last batch, and then insert a new slot for the draft token.

 **3) Multi-token drafts:** We discussed this in another PR. The problem was that for each new draft token, the MTP's KV cache needed to be updated, which was painful to do before. Now that we are using the `decode` function, it's more feasible. If the unified update/draft implementation works, we could simply increase the batch and sinfo size to make the model draft more tokens.

 These are some of my ideas. I'd appreciate any insights you might have on how to better handle some of these things, or even new ideas for improvements that I haven't spotted here.